### PR TITLE
Resolve incompatibility in ver. 0.3.17

### DIFF
--- a/tutorial-ja/106_vqe_qaoa06.ipynb
+++ b/tutorial-ja/106_vqe_qaoa06.ipynb
@@ -1,470 +1,469 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "106vqe_qaoa06.ipynb",
-      "provenance": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "ZnODbF2Hyrre"
+   },
+   "source": [
+    "#Variational Quantum Eigensolver(VQE)、QAOAセミナー 2-6（組合せ最適化問題編4）"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ZnODbF2Hyrre",
-        "colab_type": "text"
-      },
-      "source": [
-        "#Variational Quantum Eigensolver(VQE)、QAOAセミナー 2-6（組合せ最適化問題編4）"
-      ]
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "j392IPADyrh0"
+   },
+   "source": [
+    "2-5-5 Quantum Alternating Operator Ansatz\n",
+    "上記はなかなか答えが出ませんでした。ここでは、正答率を大きく上げる方法を確認します。ハミルトニアンの制約条件を定式化から外すできます。前述の交通最適化問題などは３つのルートから１つのルートを選ぶという制約式が正答率を下げる原因でしたが、今回はその制約式を減らすテクニックを確認します。\n",
+    "\n",
+    "XX+YYゲートを導入することで、01と10を入れ替える操作をできます。時間発展を見ても、入れ替え操作が見れます。最初から00と11をださず、01と10のみで計算をします。\n",
+    "\n",
+    "<img src=\"https://qiita-user-contents.imgix.net/https%3A%2F%2Fqiita-image-store.s3.ap-northeast-1.amazonaws.com%2F0%2F88256%2F0b4a9d82-8ebf-8191-23d7-dbb76396e9d1.png?ixlib=rb-1.2.2&auto=format&gif-q=60&q=75&w=1400&fit=max&s=616a52dfc97ba36e01aba646f9affdac\">\n",
+    "\n",
+    "引用：https://qiita.com/gyu-don/items/c51a9e3d5d16a6d5baf6\n",
+    "\n",
+    "これらの操作を導入して簡単な問題を解いてみます。\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "KnFuYDDZy9p-"
+   },
+   "source": [
+    "\n",
+    "##2-5-6 Quantum Alternating Operator Ansatzの例題\n",
+    "今回は初期状態に|10>と|01>のもつれ状態を採用し、途中のmixerにXYミキサーというXX+YYの時間発展を導入したものを利用してみます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 136
     },
+    "colab_type": "code",
+    "id": "wG4hCQkBzLj-",
+    "outputId": "bd14daa7-3acd-47da-e13e-8353adf15763"
+   },
+   "outputs": [
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "j392IPADyrh0",
-        "colab_type": "text"
-      },
-      "source": [
-        "2-5-5 Quantum Alternating Operator Ansatz\n",
-        "上記はなかなか答えが出ませんでした。ここでは、正答率を大きく上げる方法を確認します。ハミルトニアンの制約条件を定式化から外すできます。前述の交通最適化問題などは３つのルートから１つのルートを選ぶという制約式が正答率を下げる原因でしたが、今回はその制約式を減らすテクニックを確認します。\n",
-        "\n",
-        "XX+YYゲートを導入することで、01と10を入れ替える操作をできます。時間発展を見ても、入れ替え操作が見れます。最初から00と11をださず、01と10のみで計算をします。\n",
-        "\n",
-        "<img src=\"https://qiita-user-contents.imgix.net/https%3A%2F%2Fqiita-image-store.s3.ap-northeast-1.amazonaws.com%2F0%2F88256%2F0b4a9d82-8ebf-8191-23d7-dbb76396e9d1.png?ixlib=rb-1.2.2&auto=format&gif-q=60&q=75&w=1400&fit=max&s=616a52dfc97ba36e01aba646f9affdac\">\n",
-        "\n",
-        "引用：https://qiita.com/gyu-don/items/c51a9e3d5d16a6d5baf6\n",
-        "\n",
-        "これらの操作を導入して簡単な問題を解いてみます。\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "KnFuYDDZy9p-",
-        "colab_type": "text"
-      },
-      "source": [
-        "\n",
-        "##2-5-6 Quantum Alternating Operator Ansatzの例題\n",
-        "今回は初期状態に|10>と|01>のもつれ状態を採用し、途中のmixerにXYミキサーというXX+YYの時間発展を導入したものを利用してみます。"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "wG4hCQkBzLj-",
-        "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 136
-        },
-        "outputId": "bd14daa7-3acd-47da-e13e-8353adf15763"
-      },
-      "source": [
-        "!pip install blueqat"
-      ],
-      "execution_count": 1,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Collecting blueqat\n",
-            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/f6/73/20f9cff48caee1f69190f2e1ea93c4d7d0a745fc48defb5d3072d8337583/blueqat-0.3.13-py3-none-any.whl (50kB)\n",
-            "\r\u001b[K     |██████▌                         | 10kB 21.3MB/s eta 0:00:01\r\u001b[K     |█████████████                   | 20kB 1.8MB/s eta 0:00:01\r\u001b[K     |███████████████████▍            | 30kB 2.6MB/s eta 0:00:01\r\u001b[K     |█████████████████████████▉      | 40kB 1.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████████████| 51kB 1.7MB/s \n",
-            "\u001b[?25hRequirement already satisfied: numpy~=1.12 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.17.5)\n",
-            "Requirement already satisfied: scipy>=1.1.0 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.4.1)\n",
-            "Installing collected packages: blueqat\n",
-            "Successfully installed blueqat-0.3.13\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "A8bqofq7ynKG",
-        "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 102
-        },
-        "outputId": "db644b72-f9db-48a0-fb42-46828d4f34d9"
-      },
-      "source": [
-        "import numpy as np\n",
-        "from blueqat import Circuit\n",
-        "from blueqat.pauli import X, Y, Z, I\n",
-        "from blueqat.pauli import qubo_bit as q\n",
-        "from blueqat.vqe import AnsatzBase, Vqe\n",
-        "\n",
-        "def an(index):\n",
-        "    return 0.5 * X[index] + 0.5j * Y[index]\n",
-        "\n",
-        "def cr(index):\n",
-        "    return 0.5 * X[index] - 0.5j * Y[index]\n",
-        "\n",
-        "op = (cr(1) * an(0) + cr(0) * an(1)).to_expr().simplify()\n",
-        "\n",
-        "class QaoaQaoaAnsatz(AnsatzBase):\n",
-        "    def __init__(self, hamiltonian, step=1, init_circuit=None):\n",
-        "        super().__init__(hamiltonian, step * 2)\n",
-        "        self.hamiltonian = hamiltonian.to_expr().simplify()\n",
-        "        if not self.check_hamiltonian():\n",
-        "            raise ValueError(\"Hamiltonian terms are not commutable\")\n",
-        "\n",
-        "        self.step = step\n",
-        "        self.n_qubits = self.hamiltonian.max_n() + 1\n",
-        "        if init_circuit:\n",
-        "            self.init_circuit = init_circuit\n",
-        "            if init_circuit.n_qubits > self.n_qubits:\n",
-        "                self.n_qubits = init_circuit.n_qubits\n",
-        "        else:\n",
-        "            self.init_circuit = Circuit(self.n_qubits).h[:]\n",
-        "        self.init_circuit.make_cache()\n",
-        "        self.time_evolutions = [term.get_time_evolution() for term in self.hamiltonian]\n",
-        "        self.time_evolutions2 = [term.get_time_evolution() for term in op]\n",
-        "    def check_hamiltonian(self):\n",
-        "        \"\"\"Check hamiltonian is commutable. This condition is required for QaoaAnsatz\"\"\"\n",
-        "        return self.hamiltonian.is_all_terms_commutable()\n",
-        "\n",
-        "    def get_circuit(self, params):\n",
-        "        c = self.init_circuit.copy()\n",
-        "        betas = params[:self.step]\n",
-        "        gammas = params[self.step:]\n",
-        "        for beta, gamma in zip(betas, gammas):\n",
-        "            beta *= np.pi\n",
-        "            gamma *= 2 * np.pi\n",
-        "            for evo in self.time_evolutions:\n",
-        "                evo(c, gamma)\n",
-        "            for evo2 in self.time_evolutions2:\n",
-        "                evo2(c, beta)\n",
-        "        return c\n",
-        "\n",
-        "h = -3*q(0)-3*q(1)-2*q(0)*q(1)\n",
-        "h = h.to_expr().simplify()\n",
-        "runner = Vqe(QaoaQaoaAnsatz(h,4,Circuit().h[0].cx[0,1].x[0]))\n",
-        "result = runner.run()\n",
-        "\n",
-        "# get probability\n",
-        "print(result.most_common(12))\n",
-        "\n",
-        "print('Result by QAOA')\n",
-        "print(runner.ansatz.get_energy(result.circuit, runner.sampler))\n",
-        "\n",
-        "# Hamiltonian to matrix\n",
-        "mat = h.to_matrix()\n",
-        "\n",
-        "# Calculate by numpy\n",
-        "print('Result by numpy')\n",
-        "print(np.linalg.eigh(mat)[0][0])"
-      ],
-      "execution_count": 2,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "(((1, 0), 0.49999999999999883), ((0, 1), 0.49999999999999867), ((1, 1), 1.6023737137301796e-31), ((0, 0), 1.203706215242022e-31))\n",
-            "Result by QAOA\n",
-            "-2.999999999999993\n",
-            "Result by numpy\n",
-            "-8.0\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Pvz6c0zKzO43",
-        "colab_type": "text"
-      },
-      "source": [
-        "通常、最小基底状態は-8を選びますが、上記は|01>と|10>のもつれ状態を利用しているため、制約条件をハード制約としてもち、|00>と|11>をとることができないため、QAOAで得られる最小値の期待値は-3となっています。\n",
-        "\n",
-        "このように、通常ソフト制約として出てくるはずのハード制約をかすことで、正答率を大幅に上げることができます。回路自体は長くなっています。\n",
-        "\n",
-        "<img width=\"1281\" alt=\"スクリーンショット 2020-02-25 0.39.32.png\" src=\"https://qiita-image-store.s3.ap-northeast-1.amazonaws.com/0/218694/85efc267-c34d-dbc8-1bb0-25bc22cfb1c0.png\">"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cxaXmWR4zTYz",
-        "colab_type": "text"
-      },
-      "source": [
-        "このように、通常ソフト制約として出てくるはずのハード制約をかすことで、正答率を大幅に上げることができます。回路自体は長くなっています。\n",
-        "\n",
-        "<img width=\"1281\" alt=\"スクリーンショット 2020-02-25 0.39.32.png\" src=\"https://qiita-image-store.s3.ap-northeast-1.amazonaws.com/0/218694/85efc267-c34d-dbc8-1bb0-25bc22cfb1c0.png\">"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "A9M2QO-Fzaa6",
-        "colab_type": "text"
-      },
-      "source": [
-        "##2-5-7 量子もつれを使った制約条件項なしの交通最適化計算\n",
-        "ケーススタディとして交通最適を取り上げます。\n",
-        "量子アニーリングでは探索はほぼランダムで行われます。初期状態は|+>からスタートし、途中過程の探索は$\\sigma_x$の横磁場を使います。\n",
-        "\n",
-        "しかしここでは、ルート選択は１つだけを選ぶわけですから、$q_0$か$q_1$の片方は1で、もう片方は0となるのが条件としてついてきます。また、$q_2$と$q_3$も同様です。\n",
-        "\n",
-        "ここで、量子回路でまず量子もつれを作ります。量子もつれは多くのパターンから限られた組み合わせだけが出るように調整できるのでした。簡単な例として、"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "-1q4bT_0zFr-",
-        "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        },
-        "outputId": "58a039b5-7198-4862-9021-439fa8d45824"
-      },
-      "source": [
-        "from blueqat import Circuit\n",
-        "Circuit().h[0].cx[0,1].m[:].run(shots=100)"
-      ],
-      "execution_count": 3,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "Counter({'00': 53, '11': 47})"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 3
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "XKLwJpgFzeNn",
-        "colab_type": "text"
-      },
-      "source": [
-        "こうすると、本来４種類出るところから00と11のみ答えが出ます。\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "N9VMjLmpzcSE",
-        "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        },
-        "outputId": "02658b0e-40b6-4630-9e05-4223ed43b3ae"
-      },
-      "source": [
-        "from blueqat import Circuit\n",
-        "Circuit().h[0].cx[0,1].x[0].m[:].run(shots=100)"
-      ],
-      "execution_count": 4,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "Counter({'01': 37, '10': 63})"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 4
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "1-42sa9AzimO",
-        "colab_type": "text"
-      },
-      "source": [
-        "ちょっと形を変えることで、01と10のもつれに変更できます。\n",
-        "\n",
-        "これを使います。つまり、自動車１と自動車２にそれぞれもつれを活用して、01と10に制限をかけるように初期状態を設定します。\n",
-        "\n",
-        "今回４量子ビットの回路では、"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "NVZmMV3IzgUk",
-        "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        },
-        "outputId": "53787d5a-afea-4fe0-97d1-1b43f215b2f1"
-      },
-      "source": [
-        "from blueqat import Circuit\n",
-        "Circuit().h[0].cx[0,1].x[0].h[2].cx[2,3].x[2].m[:].run(shots=100)"
-      ],
-      "execution_count": 5,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "Counter({'0101': 31, '0110': 19, '1001': 26, '1010': 24})"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 5
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "S4Pyz-DdzqC4",
-        "colab_type": "text"
-      },
-      "source": [
-        "###入れ替え作業\n",
-        "$\\sigma_x$の横磁場での探索の代わりに明示的に(XX+YY)/2というゲートを利用することで、01と10を入れ替えることができます。\n",
-        "\n",
-        "これにより、初期状態で準備した01と10をひたすら入れ替えながら、量子断熱計算で、ハミルトニアンの最小値を求めるQAOAと組み合わせることができます。\n",
-        "\n",
-        "###具体的コード\n",
-        "具体的な実行コードはこちらです。"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "q0FnoA56znd4",
-        "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 88
-        },
-        "outputId": "db1b1222-0d56-47bd-d4eb-6b38287df3cc"
-      },
-      "source": [
-        "import numpy as np\n",
-        "from blueqat import Circuit\n",
-        "from blueqat.pauli import X, Y, Z, I\n",
-        "from blueqat.pauli import qubo_bit as q\n",
-        "from blueqat.vqe import AnsatzBase, Vqe\n",
-        "\n",
-        "def an(index):\n",
-        "    return 0.5 * X[index] + 0.5j * Y[index]\n",
-        "\n",
-        "def cr(index):\n",
-        "    return 0.5 * X[index] - 0.5j * Y[index]\n",
-        "\n",
-        "op1 = (cr(1) * an(0) + cr(0) * an(1)).to_expr().simplify()\n",
-        "op2 = (cr(3) * an(2) + cr(2) * an(3)).to_expr().simplify()\n",
-        "\n",
-        "class QaoaQaoaAnsatz(AnsatzBase):\n",
-        "    def __init__(self, hamiltonian, step=1, init_circuit=None):\n",
-        "        super().__init__(hamiltonian, step * 2)\n",
-        "        self.hamiltonian = hamiltonian.to_expr().simplify()\n",
-        "        if not self.check_hamiltonian():\n",
-        "            raise ValueError(\"Hamiltonian terms are not commutable\")\n",
-        "\n",
-        "        self.step = step\n",
-        "        self.n_qubits = self.hamiltonian.max_n() + 1\n",
-        "        if init_circuit:\n",
-        "            self.init_circuit = init_circuit\n",
-        "            if init_circuit.n_qubits > self.n_qubits:\n",
-        "                self.n_qubits = init_circuit.n_qubits\n",
-        "        else:\n",
-        "            self.init_circuit = Circuit(self.n_qubits).h[:]\n",
-        "        self.init_circuit.make_cache()\n",
-        "        self.time_evolutions = [term.get_time_evolution() for term in self.hamiltonian]\n",
-        "        self.time_evolutions1 = [term.get_time_evolution() for term in op1]\n",
-        "        self.time_evolutions2 = [term.get_time_evolution() for term in op2]\n",
-        "    def check_hamiltonian(self):\n",
-        "        \"\"\"Check hamiltonian is commutable. This condition is required for QaoaAnsatz\"\"\"\n",
-        "        return self.hamiltonian.is_all_terms_commutable()\n",
-        "\n",
-        "    def get_circuit(self, params):\n",
-        "        c = self.init_circuit.copy()\n",
-        "        betas = params[:self.step]\n",
-        "        gammas = params[self.step:]\n",
-        "        for beta, gamma in zip(betas, gammas):\n",
-        "            beta *= np.pi\n",
-        "            gamma *= 2 * np.pi\n",
-        "            for evo in self.time_evolutions:\n",
-        "                evo(c, gamma)\n",
-        "            for evo1 in self.time_evolutions1:\n",
-        "                evo1(c, beta)\n",
-        "            for evo2 in self.time_evolutions2:\n",
-        "                evo2(c, beta)\n",
-        "        return c\n",
-        "\n",
-        "h = 4*q(0)+4*q(1)+4*q(2)+4*q(3)+4*q(0)*q(1)+4*q(0)*q(2)+8*q(1)*q(2)+2*q(1)*q(3)+2*q(2)*q(3)\n",
-        "h = h.to_expr().simplify()\n",
-        "runner = Vqe(QaoaQaoaAnsatz(h,4,Circuit().h[0].cx[0,1].x[0].h[2].cx[2,3].x[2]))\n",
-        "result = runner.run()\n",
-        "\n",
-        "# get probability\n",
-        "print(result.most_common(12))\n",
-        "\n",
-        "print('Result by QAOA')\n",
-        "print(runner.ansatz.get_energy(result.circuit, runner.sampler))"
-      ],
-      "execution_count": 8,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "(((1, 0, 0, 1), 0.9761439764700606), ((0, 1, 0, 1), 0.013733180421308734), ((0, 1, 1, 0), 0.009597498113593592), ((1, 0, 1, 0), 0.0005253449950314455), ((1, 0, 1, 1), 5.616794126873087e-32), ((1, 1, 0, 1), 3.9317124248001565e-32), ((0, 0, 0, 1), 3.9117168874736404e-32), ((0, 1, 1, 1), 1.7988044180444303e-32), ((1, 0, 0, 0), 1.5407439555097884e-32), ((1, 1, 1, 0), 1.3838542217086112e-32), ((0, 0, 1, 0), 9.151450356468662e-33), ((0, 1, 0, 0), 6.995989893749367e-33))\n",
-            "Result by QAOA\n",
-            "8.106347725731453\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Ue0rJrWSz4PZ",
-        "colab_type": "text"
-      },
-      "source": [
-        "とても高い確率で制約条件を満たしながら混雑の最も少ないルートが選択されています。\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "tndRHOhQzvki",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        ""
-      ],
-      "execution_count": 0,
-      "outputs": []
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting blueqat\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/f6/73/20f9cff48caee1f69190f2e1ea93c4d7d0a745fc48defb5d3072d8337583/blueqat-0.3.13-py3-none-any.whl (50kB)\n",
+      "\r",
+      "\u001b[K     |██████▌                         | 10kB 21.3MB/s eta 0:00:01\r",
+      "\u001b[K     |█████████████                   | 20kB 1.8MB/s eta 0:00:01\r",
+      "\u001b[K     |███████████████████▍            | 30kB 2.6MB/s eta 0:00:01\r",
+      "\u001b[K     |█████████████████████████▉      | 40kB 1.7MB/s eta 0:00:01\r",
+      "\u001b[K     |████████████████████████████████| 51kB 1.7MB/s \n",
+      "\u001b[?25hRequirement already satisfied: numpy~=1.12 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.17.5)\n",
+      "Requirement already satisfied: scipy>=1.1.0 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.4.1)\n",
+      "Installing collected packages: blueqat\n",
+      "Successfully installed blueqat-0.3.13\n"
+     ]
     }
-  ]
+   ],
+   "source": [
+    "!pip install blueqat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 102
+    },
+    "colab_type": "code",
+    "id": "A8bqofq7ynKG",
+    "outputId": "db644b72-f9db-48a0-fb42-46828d4f34d9"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(((0, 1), 0.4999999999999996), ((1, 0), 0.49999999999999944), ((1, 1), 1.7333369499485123e-31), ((0, 0), 5.623715437610729e-32))\n",
+      "Result by QAOA\n",
+      "-2.9999999999999973\n",
+      "Result by numpy\n",
+      "-8.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from blueqat import Circuit\n",
+    "from blueqat.pauli import X, Y, Z, I\n",
+    "from blueqat.pauli import qubo_bit as q\n",
+    "from blueqat.vqe import AnsatzBase, Vqe\n",
+    "\n",
+    "def an(index):\n",
+    "    return 0.5 * X[index] + 0.5j * Y[index]\n",
+    "\n",
+    "def cr(index):\n",
+    "    return 0.5 * X[index] - 0.5j * Y[index]\n",
+    "\n",
+    "op = (cr(1) * an(0) + cr(0) * an(1)).to_expr().simplify()\n",
+    "\n",
+    "class QaoaQaoaAnsatz(AnsatzBase):\n",
+    "    def __init__(self, hamiltonian, step=1, init_circuit=None):\n",
+    "        super().__init__(hamiltonian, step * 2)\n",
+    "        self.hamiltonian = hamiltonian.to_expr().simplify()\n",
+    "        if not self.check_hamiltonian():\n",
+    "            raise ValueError(\"Hamiltonian terms are not commutable\")\n",
+    "\n",
+    "        self.step = step\n",
+    "        self.n_qubits = self.hamiltonian.max_n() + 1\n",
+    "        if init_circuit:\n",
+    "            self.init_circuit = init_circuit\n",
+    "            if init_circuit.n_qubits > self.n_qubits:\n",
+    "                self.n_qubits = init_circuit.n_qubits\n",
+    "        else:\n",
+    "            self.init_circuit = Circuit(self.n_qubits).h[:]\n",
+    "        self.init_circuit.make_cache()\n",
+    "        self.time_evolutions = [term.get_time_evolution() for term in self.hamiltonian]\n",
+    "        self.time_evolutions2 = [term.get_time_evolution() for term in op]\n",
+    "    def check_hamiltonian(self):\n",
+    "        \"\"\"Check hamiltonian is commutable. This condition is required for QaoaAnsatz\"\"\"\n",
+    "        return self.hamiltonian.is_all_terms_commutable()\n",
+    "\n",
+    "    def get_circuit(self, params):\n",
+    "        c = self.init_circuit.copy()\n",
+    "        betas = params[:self.step]\n",
+    "        gammas = params[self.step:]\n",
+    "        for beta, gamma in zip(betas, gammas):\n",
+    "            beta *= np.pi\n",
+    "            gamma *= 2 * np.pi\n",
+    "            for evo in self.time_evolutions:\n",
+    "                evo(c, gamma)\n",
+    "            for evo2 in self.time_evolutions2:\n",
+    "                evo2(c, beta)\n",
+    "        return c\n",
+    "\n",
+    "h = -3*q(0)-3*q(1)-2*q(0)*q(1)\n",
+    "h = h.to_expr().simplify()\n",
+    "runner = Vqe(QaoaQaoaAnsatz(h,4,Circuit().h[0].cx[0,1].x[0]))\n",
+    "result = runner.run()\n",
+    "\n",
+    "# get probability\n",
+    "print(result.most_common(12))\n",
+    "\n",
+    "print('Result by QAOA')\n",
+    "print(runner.ansatz.get_energy_sparse(result.circuit))\n",
+    "\n",
+    "# Hamiltonian to matrix\n",
+    "mat = h.to_matrix()\n",
+    "\n",
+    "# Calculate by numpy\n",
+    "print('Result by numpy')\n",
+    "print(np.linalg.eigh(mat)[0][0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Pvz6c0zKzO43"
+   },
+   "source": [
+    "通常、最小基底状態は-8を選びますが、上記は|01>と|10>のもつれ状態を利用しているため、制約条件をハード制約としてもち、|00>と|11>をとることができないため、QAOAで得られる最小値の期待値は-3となっています。\n",
+    "\n",
+    "このように、通常ソフト制約として出てくるはずのハード制約をかすことで、正答率を大幅に上げることができます。回路自体は長くなっています。\n",
+    "\n",
+    "<img width=\"1281\" alt=\"スクリーンショット 2020-02-25 0.39.32.png\" src=\"https://qiita-image-store.s3.ap-northeast-1.amazonaws.com/0/218694/85efc267-c34d-dbc8-1bb0-25bc22cfb1c0.png\">"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "cxaXmWR4zTYz"
+   },
+   "source": [
+    "このように、通常ソフト制約として出てくるはずのハード制約をかすことで、正答率を大幅に上げることができます。回路自体は長くなっています。\n",
+    "\n",
+    "<img width=\"1281\" alt=\"スクリーンショット 2020-02-25 0.39.32.png\" src=\"https://qiita-image-store.s3.ap-northeast-1.amazonaws.com/0/218694/85efc267-c34d-dbc8-1bb0-25bc22cfb1c0.png\">"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "A9M2QO-Fzaa6"
+   },
+   "source": [
+    "##2-5-7 量子もつれを使った制約条件項なしの交通最適化計算\n",
+    "ケーススタディとして交通最適を取り上げます。\n",
+    "量子アニーリングでは探索はほぼランダムで行われます。初期状態は|+>からスタートし、途中過程の探索は$\\sigma_x$の横磁場を使います。\n",
+    "\n",
+    "しかしここでは、ルート選択は１つだけを選ぶわけですから、$q_0$か$q_1$の片方は1で、もう片方は0となるのが条件としてついてきます。また、$q_2$と$q_3$も同様です。\n",
+    "\n",
+    "ここで、量子回路でまず量子もつれを作ります。量子もつれは多くのパターンから限られた組み合わせだけが出るように調整できるのでした。簡単な例として、"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "colab_type": "code",
+    "id": "-1q4bT_0zFr-",
+    "outputId": "58a039b5-7198-4862-9021-439fa8d45824"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Counter({'11': 53, '00': 47})"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from blueqat import Circuit\n",
+    "Circuit().h[0].cx[0,1].m[:].run(shots=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "XKLwJpgFzeNn"
+   },
+   "source": [
+    "こうすると、本来４種類出るところから00と11のみ答えが出ます。\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "colab_type": "code",
+    "id": "N9VMjLmpzcSE",
+    "outputId": "02658b0e-40b6-4630-9e05-4223ed43b3ae"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Counter({'01': 59, '10': 41})"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from blueqat import Circuit\n",
+    "Circuit().h[0].cx[0,1].x[0].m[:].run(shots=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "1-42sa9AzimO"
+   },
+   "source": [
+    "ちょっと形を変えることで、01と10のもつれに変更できます。\n",
+    "\n",
+    "これを使います。つまり、自動車１と自動車２にそれぞれもつれを活用して、01と10に制限をかけるように初期状態を設定します。\n",
+    "\n",
+    "今回４量子ビットの回路では、"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "colab_type": "code",
+    "id": "NVZmMV3IzgUk",
+    "outputId": "53787d5a-afea-4fe0-97d1-1b43f215b2f1"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Counter({'0110': 33, '1001': 24, '0101': 19, '1010': 24})"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from blueqat import Circuit\n",
+    "Circuit().h[0].cx[0,1].x[0].h[2].cx[2,3].x[2].m[:].run(shots=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "S4Pyz-DdzqC4"
+   },
+   "source": [
+    "###入れ替え作業\n",
+    "$\\sigma_x$の横磁場での探索の代わりに明示的に(XX+YY)/2というゲートを利用することで、01と10を入れ替えることができます。\n",
+    "\n",
+    "これにより、初期状態で準備した01と10をひたすら入れ替えながら、量子断熱計算で、ハミルトニアンの最小値を求めるQAOAと組み合わせることができます。\n",
+    "\n",
+    "###具体的コード\n",
+    "具体的な実行コードはこちらです。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 88
+    },
+    "colab_type": "code",
+    "id": "q0FnoA56znd4",
+    "outputId": "db1b1222-0d56-47bd-d4eb-6b38287df3cc"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(((1, 0, 0, 1), 0.8112133792184058), ((0, 1, 0, 1), 0.09121447195335018), ((1, 0, 1, 0), 0.06340958241714689), ((0, 1, 1, 0), 0.03416256641109033), ((0, 0, 0, 1), 1.409502470243749e-31), ((1, 0, 0, 0), 6.548161810916602e-32), ((1, 1, 1, 0), 5.105576867286511e-32), ((1, 1, 0, 1), 4.7792585722809673e-32), ((0, 1, 0, 0), 3.8518598887744717e-32), ((1, 0, 1, 1), 9.485204976107137e-33), ((0, 0, 1, 0), 8.288258806869007e-33), ((0, 1, 1, 1), 1.3601880232234853e-33))\n",
+      "Result by QAOA\n",
+      "8.709367804863955\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from blueqat import Circuit\n",
+    "from blueqat.pauli import X, Y, Z, I\n",
+    "from blueqat.pauli import qubo_bit as q\n",
+    "from blueqat.vqe import AnsatzBase, Vqe\n",
+    "\n",
+    "def an(index):\n",
+    "    return 0.5 * X[index] + 0.5j * Y[index]\n",
+    "\n",
+    "def cr(index):\n",
+    "    return 0.5 * X[index] - 0.5j * Y[index]\n",
+    "\n",
+    "op1 = (cr(1) * an(0) + cr(0) * an(1)).to_expr().simplify()\n",
+    "op2 = (cr(3) * an(2) + cr(2) * an(3)).to_expr().simplify()\n",
+    "\n",
+    "class QaoaQaoaAnsatz(AnsatzBase):\n",
+    "    def __init__(self, hamiltonian, step=1, init_circuit=None):\n",
+    "        super().__init__(hamiltonian, step * 2)\n",
+    "        self.hamiltonian = hamiltonian.to_expr().simplify()\n",
+    "        if not self.check_hamiltonian():\n",
+    "            raise ValueError(\"Hamiltonian terms are not commutable\")\n",
+    "\n",
+    "        self.step = step\n",
+    "        self.n_qubits = self.hamiltonian.max_n() + 1\n",
+    "        if init_circuit:\n",
+    "            self.init_circuit = init_circuit\n",
+    "            if init_circuit.n_qubits > self.n_qubits:\n",
+    "                self.n_qubits = init_circuit.n_qubits\n",
+    "        else:\n",
+    "            self.init_circuit = Circuit(self.n_qubits).h[:]\n",
+    "        self.init_circuit.make_cache()\n",
+    "        self.time_evolutions = [term.get_time_evolution() for term in self.hamiltonian]\n",
+    "        self.time_evolutions1 = [term.get_time_evolution() for term in op1]\n",
+    "        self.time_evolutions2 = [term.get_time_evolution() for term in op2]\n",
+    "    def check_hamiltonian(self):\n",
+    "        \"\"\"Check hamiltonian is commutable. This condition is required for QaoaAnsatz\"\"\"\n",
+    "        return self.hamiltonian.is_all_terms_commutable()\n",
+    "\n",
+    "    def get_circuit(self, params):\n",
+    "        c = self.init_circuit.copy()\n",
+    "        betas = params[:self.step]\n",
+    "        gammas = params[self.step:]\n",
+    "        for beta, gamma in zip(betas, gammas):\n",
+    "            beta *= np.pi\n",
+    "            gamma *= 2 * np.pi\n",
+    "            for evo in self.time_evolutions:\n",
+    "                evo(c, gamma)\n",
+    "            for evo1 in self.time_evolutions1:\n",
+    "                evo1(c, beta)\n",
+    "            for evo2 in self.time_evolutions2:\n",
+    "                evo2(c, beta)\n",
+    "        return c\n",
+    "\n",
+    "h = 4*q(0)+4*q(1)+4*q(2)+4*q(3)+4*q(0)*q(1)+4*q(0)*q(2)+8*q(1)*q(2)+2*q(1)*q(3)+2*q(2)*q(3)\n",
+    "h = h.to_expr().simplify()\n",
+    "runner = Vqe(QaoaQaoaAnsatz(h,4,Circuit().h[0].cx[0,1].x[0].h[2].cx[2,3].x[2]))\n",
+    "result = runner.run()\n",
+    "\n",
+    "# get probability\n",
+    "print(result.most_common(12))\n",
+    "\n",
+    "print('Result by QAOA')\n",
+    "print(runner.ansatz.get_energy_sparse(result.circuit))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Ue0rJrWSz4PZ"
+   },
+   "source": [
+    "とても高い確率で制約条件を満たしながら混雑の最も少ないルートが選択されています。\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "106vqe_qaoa06.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/tutorial-ja/200_vqe_ja.ipynb
+++ b/tutorial-ja/200_vqe_ja.ipynb
@@ -89,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -99,7 +99,7 @@
        "       [-4.56+2.45j, -1.11+0.j  ]])"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -241,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -249,7 +249,7 @@
      "output_type": "stream",
      "text": [
       "Result by VQE\n",
-      "-4.4508041744242\n",
+      "-4.236663568691615\n",
       "Result by numpy\n",
       "-4.450818602983201\n"
      ]
@@ -277,7 +277,7 @@
     "result = runner.run()\n",
     "\n",
     "print('Result by VQE')\n",
-    "print(runner.ansatz.get_energy(result.circuit, runner.sampler))\n",
+    "print(runner.ansatz.get_energy_sparse(result.circuit))\n",
     "\n",
     "# This is for check\n",
     "mat = h.to_matrix()\n",
@@ -295,9 +295,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "conda_python3",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda_python3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -309,7 +309,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/tutorial-ja/300_cop_ja.ipynb
+++ b/tutorial-ja/300_cop_ja.ipynb
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -193,7 +193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 3,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -209,7 +209,7 @@
      "output_type": "stream",
      "text": [
       "Result by VQE\n",
-      "-1.999996764485408\n"
+      "-1.999998714607245\n"
      ]
     }
    ],
@@ -233,7 +233,7 @@
     "result = runner.run()\n",
     "\n",
     "print('Result by VQE')\n",
-    "print(runner.ansatz.get_energy(result.circuit, runner.sampler))"
+    "print(runner.ansatz.get_energy_sparse(result.circuit))"
    ]
   },
   {
@@ -261,14 +261,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-1.9990618300718008\n"
+      "-1.7919100877330898\n"
      ]
     }
    ],
@@ -281,7 +281,7 @@
     "runner = Vqe(vqe.QaoaAnsatz(h, step))\n",
     "result = runner.run()\n",
     "\n",
-    "print(runner.ansatz.get_energy(result.circuit, runner.sampler))"
+    "print(runner.ansatz.get_energy_sparse(result.circuit))"
    ]
   },
   {
@@ -300,7 +300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 6,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -315,7 +315,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(((1, 1), 0.9785088365668992), ((0, 0), 0.020082141355688456), ((0, 1), 0.0007045110387061985), ((1, 0), 0.0007045110387061852))\n"
+      "(((1, 1), 0.9571688060369407), ((0, 0), 0.02264678008376087), ((0, 1), 0.010092206939649306), ((1, 0), 0.010092206939649295))\n"
      ]
     }
    ],
@@ -339,7 +339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -356,7 +356,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -365,7 +365,7 @@
        "[1, 1]"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -387,14 +387,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(((1, 1), 0.9708899323220557), ((0, 0), 0.027924352975247094), ((1, 0), 0.0005928573513485099), ((0, 1), 0.000592857351348508))\n"
+      "(((1, 1), 0.9872629031715499), ((0, 0), 0.01265996782202954), ((0, 1), 3.856450321039442e-05), ((1, 0), 3.856450321039259e-05))\n"
      ]
     }
    ],
@@ -420,9 +420,9 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "conda_python3",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda_python3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -434,7 +434,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/tutorial-ja/400_chemistry_ja.ipynb
+++ b/tutorial-ja/400_chemistry_ja.ipynb
@@ -1,585 +1,589 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "102vqe_qaoa02.ipynb",
-      "provenance": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "0DeQHhKHtIS9"
+   },
+   "source": [
+    "#Variational Quantum Eigensolver(VQE)、QAOAセミナー 2-2（VQEで量子化学計算編）"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "0DeQHhKHtIS9",
-        "colab_type": "text"
-      },
-      "source": [
-        "#Variational Quantum Eigensolver(VQE)、QAOAセミナー 2-2（VQEで量子化学計算編）"
-      ]
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "xoLga_-FtPxy"
+   },
+   "source": [
+    "量子化学計算はハミルトニアンの作成をパウリ行列を使って行い、VQEを利用して解を得ることができます。量子化学計算はハミルトニアンに対応するansatzの研究が進んでおり、課題として見通しが他の問題よりもよくなっています。\n",
+    "\n",
+    "##2-3-1 追加のインストール\n",
+    "追加でツールのインストールが必要です。\n",
+    "今回は、blueqatに追加で、openfermionblueqatとopenfermionを追加します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 1000
     },
+    "colab_type": "code",
+    "id": "_NQIdXmptSJU",
+    "outputId": "6bf7e471-8b28-4512-a21b-4e5320d60561"
+   },
+   "outputs": [
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "xoLga_-FtPxy",
-        "colab_type": "text"
-      },
-      "source": [
-        "量子化学計算はハミルトニアンの作成をパウリ行列を使って行い、VQEを利用して解を得ることができます。量子化学計算はハミルトニアンに対応するansatzの研究が進んでおり、課題として見通しが他の問題よりもよくなっています。\n",
-        "\n",
-        "##2-3-1 追加のインストール\n",
-        "追加でツールのインストールが必要です。\n",
-        "今回は、blueqatに追加で、openfermionblueqatとopenfermionを追加します。"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "_NQIdXmptSJU",
-        "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 1000
-        },
-        "outputId": "6bf7e471-8b28-4512-a21b-4e5320d60561"
-      },
-      "source": [
-        "!pip3 install blueqat openfermionblueqat openfermion"
-      ],
-      "execution_count": 1,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Collecting blueqat\n",
-            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/f6/73/20f9cff48caee1f69190f2e1ea93c4d7d0a745fc48defb5d3072d8337583/blueqat-0.3.13-py3-none-any.whl (50kB)\n",
-            "\r\u001b[K     |██████▌                         | 10kB 13.4MB/s eta 0:00:01\r\u001b[K     |█████████████                   | 20kB 3.0MB/s eta 0:00:01\r\u001b[K     |███████████████████▍            | 30kB 3.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████████▉      | 40kB 2.9MB/s eta 0:00:01\r\u001b[K     |████████████████████████████████| 51kB 2.4MB/s \n",
-            "\u001b[?25hCollecting openfermionblueqat\n",
-            "  Downloading https://files.pythonhosted.org/packages/e0/ef/d2a4242ef5f4ff518921dfd608d7841f476e947bc23efc25bd7c3ba0042d/openfermionblueqat-0.2.2-py3-none-any.whl\n",
-            "Collecting openfermion\n",
-            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/66/72/e058e3d8ececd54212bb98848e8e8227d4887fed6fe8d87f425a034add8b/openfermion-0.10.0.tar.gz (625kB)\n",
-            "\u001b[K     |████████████████████████████████| 634kB 8.8MB/s \n",
-            "\u001b[?25hRequirement already satisfied: scipy>=1.1.0 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.4.1)\n",
-            "Requirement already satisfied: numpy~=1.12 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.17.5)\n",
-            "Requirement already satisfied: h5py>=2.8 in /usr/local/lib/python3.6/dist-packages (from openfermion) (2.8.0)\n",
-            "Requirement already satisfied: future in /usr/local/lib/python3.6/dist-packages (from openfermion) (0.16.0)\n",
-            "Requirement already satisfied: jupyter in /usr/local/lib/python3.6/dist-packages (from openfermion) (1.0.0)\n",
-            "Requirement already satisfied: nbformat in /usr/local/lib/python3.6/dist-packages (from openfermion) (5.0.4)\n",
-            "Requirement already satisfied: networkx in /usr/local/lib/python3.6/dist-packages (from openfermion) (2.4)\n",
-            "Requirement already satisfied: matplotlib in /usr/local/lib/python3.6/dist-packages (from openfermion) (3.1.3)\n",
-            "Collecting pubchempy\n",
-            "  Downloading https://files.pythonhosted.org/packages/aa/fb/8de3aa9804b614dbc8dc5c16ed061d819cc360e0ddecda3dcd01c1552339/PubChemPy-1.0.4.tar.gz\n",
-            "Requirement already satisfied: six in /usr/local/lib/python3.6/dist-packages (from openfermion) (1.12.0)\n",
-            "Requirement already satisfied: qtconsole in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (4.6.0)\n",
-            "Requirement already satisfied: ipywidgets in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (7.5.1)\n",
-            "Requirement already satisfied: jupyter-console in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (5.2.0)\n",
-            "Requirement already satisfied: notebook in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (5.2.2)\n",
-            "Requirement already satisfied: nbconvert in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (5.6.1)\n",
-            "Requirement already satisfied: ipykernel in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (4.6.1)\n",
-            "Requirement already satisfied: jsonschema!=2.5.0,>=2.4 in /usr/local/lib/python3.6/dist-packages (from nbformat->openfermion) (2.6.0)\n",
-            "Requirement already satisfied: traitlets>=4.1 in /usr/local/lib/python3.6/dist-packages (from nbformat->openfermion) (4.3.3)\n",
-            "Requirement already satisfied: ipython-genutils in /usr/local/lib/python3.6/dist-packages (from nbformat->openfermion) (0.2.0)\n",
-            "Requirement already satisfied: jupyter-core in /usr/local/lib/python3.6/dist-packages (from nbformat->openfermion) (4.6.2)\n",
-            "Requirement already satisfied: decorator>=4.3.0 in /usr/local/lib/python3.6/dist-packages (from networkx->openfermion) (4.4.1)\n",
-            "Requirement already satisfied: kiwisolver>=1.0.1 in /usr/local/lib/python3.6/dist-packages (from matplotlib->openfermion) (1.1.0)\n",
-            "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.6/dist-packages (from matplotlib->openfermion) (0.10.0)\n",
-            "Requirement already satisfied: pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 in /usr/local/lib/python3.6/dist-packages (from matplotlib->openfermion) (2.4.6)\n",
-            "Requirement already satisfied: python-dateutil>=2.1 in /usr/local/lib/python3.6/dist-packages (from matplotlib->openfermion) (2.6.1)\n",
-            "Requirement already satisfied: pygments in /usr/local/lib/python3.6/dist-packages (from qtconsole->jupyter->openfermion) (2.1.3)\n",
-            "Requirement already satisfied: jupyter-client>=4.1 in /usr/local/lib/python3.6/dist-packages (from qtconsole->jupyter->openfermion) (5.3.4)\n",
-            "Requirement already satisfied: ipython>=4.0.0; python_version >= \"3.3\" in /usr/local/lib/python3.6/dist-packages (from ipywidgets->jupyter->openfermion) (5.5.0)\n",
-            "Requirement already satisfied: widgetsnbextension~=3.5.0 in /usr/local/lib/python3.6/dist-packages (from ipywidgets->jupyter->openfermion) (3.5.1)\n",
-            "Requirement already satisfied: prompt-toolkit<2.0.0,>=1.0.0 in /usr/local/lib/python3.6/dist-packages (from jupyter-console->jupyter->openfermion) (1.0.18)\n",
-            "Requirement already satisfied: tornado>=4 in /usr/local/lib/python3.6/dist-packages (from notebook->jupyter->openfermion) (4.5.3)\n",
-            "Requirement already satisfied: terminado>=0.3.3; sys_platform != \"win32\" in /usr/local/lib/python3.6/dist-packages (from notebook->jupyter->openfermion) (0.8.3)\n",
-            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.6/dist-packages (from notebook->jupyter->openfermion) (2.11.1)\n",
-            "Requirement already satisfied: mistune<2,>=0.8.1 in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (0.8.4)\n",
-            "Requirement already satisfied: entrypoints>=0.2.2 in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (0.3)\n",
-            "Requirement already satisfied: bleach in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (3.1.0)\n",
-            "Requirement already satisfied: testpath in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (0.4.4)\n",
-            "Requirement already satisfied: defusedxml in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (0.6.0)\n",
-            "Requirement already satisfied: pandocfilters>=1.4.1 in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (1.4.2)\n",
-            "Requirement already satisfied: setuptools in /usr/local/lib/python3.6/dist-packages (from kiwisolver>=1.0.1->matplotlib->openfermion) (45.1.0)\n",
-            "Requirement already satisfied: pyzmq>=13 in /usr/local/lib/python3.6/dist-packages (from jupyter-client>=4.1->qtconsole->jupyter->openfermion) (17.0.0)\n",
-            "Requirement already satisfied: simplegeneric>0.8 in /usr/local/lib/python3.6/dist-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets->jupyter->openfermion) (0.8.1)\n",
-            "Requirement already satisfied: pickleshare in /usr/local/lib/python3.6/dist-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets->jupyter->openfermion) (0.7.5)\n",
-            "Requirement already satisfied: pexpect; sys_platform != \"win32\" in /usr/local/lib/python3.6/dist-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets->jupyter->openfermion) (4.8.0)\n",
-            "Requirement already satisfied: wcwidth in /usr/local/lib/python3.6/dist-packages (from prompt-toolkit<2.0.0,>=1.0.0->jupyter-console->jupyter->openfermion) (0.1.8)\n",
-            "Requirement already satisfied: ptyprocess; os_name != \"nt\" in /usr/local/lib/python3.6/dist-packages (from terminado>=0.3.3; sys_platform != \"win32\"->notebook->jupyter->openfermion) (0.6.0)\n",
-            "Requirement already satisfied: MarkupSafe>=0.23 in /usr/local/lib/python3.6/dist-packages (from jinja2->notebook->jupyter->openfermion) (1.1.1)\n",
-            "Requirement already satisfied: webencodings in /usr/local/lib/python3.6/dist-packages (from bleach->nbconvert->jupyter->openfermion) (0.5.1)\n",
-            "Building wheels for collected packages: openfermion, pubchempy\n",
-            "  Building wheel for openfermion (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
-            "  Created wheel for openfermion: filename=openfermion-0.10.0-cp36-none-any.whl size=731375 sha256=b376fd0f66f7ad4e2d5b4244a8ed6bdfe83674c2cb123f62b0f58ab24af5c6b9\n",
-            "  Stored in directory: /root/.cache/pip/wheels/3c/49/cd/098bb337ffcbb70021864403773043df332c065590873f1813\n",
-            "  Building wheel for pubchempy (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
-            "  Created wheel for pubchempy: filename=PubChemPy-1.0.4-cp36-none-any.whl size=13825 sha256=170181c246083c6094378e11cb63d2801a0ba573cefb45615659e2c69fd0e1eb\n",
-            "  Stored in directory: /root/.cache/pip/wheels/10/4d/51/6b843681a9a5aef35f0d0fbce243de46f85080036e16118752\n",
-            "Successfully built openfermion pubchempy\n",
-            "Installing collected packages: blueqat, pubchempy, openfermion, openfermionblueqat\n",
-            "Successfully installed blueqat-0.3.13 openfermion-0.10.0 openfermionblueqat-0.2.2 pubchempy-1.0.4\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "HHLJDoRXtXta",
-        "colab_type": "text"
-      },
-      "source": [
-        "##2-3-2 コードをざっくり\n",
-        "今回はopenfermionに準備されたコードを使います。"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "hDacEDd6tVIK",
-        "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 283
-        },
-        "outputId": "cdb33658-119e-4c37-caf6-04d06ba417b7"
-      },
-      "source": [
-        "from blueqat import *\n",
-        "from openfermion import *\n",
-        "from openfermionblueqat import*\n",
-        "import numpy as np\n",
-        "\n",
-        "def get_molecule(bond_len):\n",
-        "  geometry = [('H',(0.,0.,0.)),('H',(0.,0.,bond_len))]\n",
-        "\n",
-        "  description = format(bond_len)\n",
-        "  molecule = MolecularData(geometry, \"sto-3g\",1,description=description)\n",
-        "\n",
-        "  molecule.load()\n",
-        "  return molecule\n",
-        "\n",
-        "x = [];e=[];fullci=[]\n",
-        "for bond_len in np.arange(0.2,2.5,0.1):\n",
-        "  m = get_molecule(\"{:.2}\".format(bond_len))\n",
-        "  h = bravyi_kitaev(get_fermion_operator(m.get_molecular_hamiltonian()))\n",
-        "  runner = vqe.Vqe(UCCAnsatz(h,6,Circuit().x[0]))\n",
-        "  result = runner.run()\n",
-        "  x.append(bond_len)\n",
-        "  e.append(runner.ansatz.get_energy(result.circuit,runner.sampler))\n",
-        "  fullci.append(m.fci_energy)\n",
-        "\n",
-        "%matplotlib inline\n",
-        "import matplotlib.pyplot as plt\n",
-        "plt.plot(x,fullci)\n",
-        "plt.plot(x,e,\"o\")"
-      ],
-      "execution_count": 2,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "[<matplotlib.lines.Line2D at 0x7fd883233c88>]"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 2
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYMAAAD5CAYAAADFqlkBAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0\ndHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nO3de3hc1X3u8e9vdB1b1sWWZN2sGIMx\nGMfBRTgmEIKDCQkJt6QB0uSUpE2dJqW0SfOcktISQnrhNE9KoU1O45I8IUl7EjeBYAqUGodLLg0g\nwBiMARsTsHyVZUu+6D7zO3/MCGRpj0bSjGakmffzPHpmz569Zy0243lnr7X22ubuiIhIfgtluwIi\nIpJ9CgMREVEYiIiIwkBERFAYiIgICgMREQEK0/EmZvZ+4HagALjT3W8d8foXgE8Dg0A78Hvu/nqy\n962urvaFCxemo4oiInnh6aefPujuNRPdL+UwMLMC4BvARUAb8JSZbXD3F4dt9izQ4u7dZvZZ4O+B\nq5O998KFC2ltbU21iiIiecPMkv7QDpKOZqKVwA533+nu/cAPgcuHb+Duj7h7d/zpr4GmNJQrIiJp\nko4waAR2DXveFl+XyO8DD6ahXBERSZO09BmMl5l9AmgB3jPGNmuBtQDNzc0ZqpmISH5Lx5nBbmDB\nsOdN8XUnMLM1wI3AZe7el+jN3H2du7e4e0tNzYT7QEREZBLSEQZPAYvN7CQzKwauATYM38DMVgDf\nIhYEB9JQpoiIpFHKYeDug8B1wEPANmC9u281s1vM7LL4Zl8DyoD/MLPNZrYhwdulbst6uG0Z3FwZ\ne9yyfsqKEhHJFWnpM3D3B4AHRqy7adjymnSUk9SW9XDf9TDQE3vetSv2HGD5VRmpgojITJRbVyBv\nuuWtIBgy0BNbLyIiCeVWGHS1TWy9iIgAuRYGFQmuZUu0XkREgFwLgwtvgqLwieuKwrH1IiKSUG6F\nwfKr4NI76CyaTxSDigVw6R3qPBYRSSKjVyBnxPKr+NHhs/i7B19iyw3vo7y0KNs1EhGZ9nLrzCCu\nsSrWVLSnsyfJliIiAjkaBg2VCgMRkYnIyTBoiofB7sMKAxGR8cjJMKguK6G4IMTuzt5sV0VEZEbI\nyTAIhYz6ylJ2q5lIRGRccjIMABoqwuozEBEZp5wNg8aqsPoMRETGKWfDoKEyzP6jvQxEotmuiojI\ntJezYdBUGcYd9nWpE1lEJJmcDYOhaw3UiSwiklzOhsHQVcjqNxARSS5nw6C+ohTQmYGIyHjkbBiU\nFhVQXVai4aUiIuOQs2EA0KgLz0RExiW3w6AqrDAQERmHnA6DoauQ3T3bVRERmdbSEgZm9n4ze9nM\ndpjZDQGvl5jZj+KvP2FmC9NRbjKNVWF6B6IcOt6fieJERGaslMPAzAqAbwAfAJYCHzOzpSM2+33g\nsLufAtwG/J9Uyx2PRl1rICIyLuk4M1gJ7HD3ne7eD/wQuHzENpcDd8WXfwxcaGaWhrLHpJvciIiM\nTzrCoBHYNex5W3xd4DbuPgh0AfOC3szM1ppZq5m1tre3p1SxpviFZ2268ExEZEzTrgPZ3de5e4u7\nt9TU1KT0XhXhImYVF7BHN7kRERlTOsJgN7Bg2POm+LrAbcysEKgAOtJQ9pjMjMbKMLs7u6e6KBGR\nGS0dYfAUsNjMTjKzYuAaYMOIbTYA18aXfxv4mWdovGdDZVhnBiIiSaQcBvE+gOuAh4BtwHp332pm\nt5jZZfHNvg3MM7MdwBeAUcNPp4ouPBMRSa4wHW/i7g8AD4xYd9Ow5V7go+koa6IaK8McOt5PT3+E\ncHFBNqogIjLtTbsO5HTTtQYiIsnlfBjoWgMRkeRyPgzevMmNwkBEJKGcD4P5c0ooCJnueCYiMoac\nD4PCghB15aVqJhIRGUPOhwFAQ2UpbQoDEZGE8iIMGivDOjMQERlDXoRBQ2WYfV29RKK6yY2ISJC8\nCIPGqjCDUefAUU1LISISJC/CYOhaA40oEhEJlhdh0KSrkEVExpQXYdCgMBARGVNehMHskkIqZxVp\nRJGISAJ5EQYQG16qPgMRkWB5Ewa6yY2ISGJ5Ewax21/2kKEbrImIzCh5FQbH+gY50juY7aqIiEw7\n+RMGVbrWQEQkkbwJAw0vFRFJLG/CoFF3PBMRSShvwmDe7GKKC0M6MxARCZBSGJjZXDPbaGbb449V\nAducaWb/Y2ZbzWyLmV2dSpmTFQrZmyOKRETkRKmeGdwAbHL3xcCm+PORuoHfdfczgPcD/2hmlSmW\nOykNlaXqQBYRCZBqGFwO3BVfvgu4YuQG7v6Ku2+PL+8BDgA1KZY7KbrJjYhIsFTDYL67740v7wPm\nj7Wxma0EioFXUyx3Uhoqwxw42kffYCQbxYuITFuFyTYws4eBuoCXbhz+xN3dzBJe3mtm9cD3gWvd\nPTrGdmuBtQDNzc3JqjchQyOK9nX18rZ5s9P63iIiM1nSMHD3NYleM7P9Zlbv7nvjX/YHEmxXDtwP\n3Ojuv05S3jpgHUBLS0ta545oHHaTG4WBiMhbUm0m2gBcG1++Frh35AZmVgzcA3zP3X+cYnkpefMq\nZPUbiIicINUwuBW4yMy2A2vizzGzFjO7M77NVcD5wCfNbHP878wUy52UuopSQGEgIjJS0maisbh7\nB3BhwPpW4NPx5R8AP0ilnHQpKSygdk6JRhSJiIyQN1cgD2nQhWciIqPkXRg0VukmNyIiI+VfGMTP\nDKJR3eRGRGRIXoZB/2CUjuP92a6KiMi0kZdhABpRJCIyXN6FQUOl7ngmIjJS3oXB0IVnGl4qIvKW\nvAuD8tJCykoK1UwkIjJM3oWBmW5yIyIyUt6FAegmNyIiI+VlGDRWhdnTpTAQERmSl2HQUBmms3uA\n432D2a6KiMi0kJdhMHStgUYUiYjE5HUYtCkMRESAfA0DXWsgInKCvAyD2jmlFIZMI4pEROLyMgwK\nQkZdRanODERE4vIyDEA3uRERGS5vw6CpUje5EREZkrdh0FAZZt+RXgYj0WxXRUQk6/I2DBqrwkSi\nzv6jfdmuiohI1uVtGOi+BiIib0k5DMxsrpltNLPt8ceqMbYtN7M2M/vnVMtN1Vt3POvOck1ERLIv\nHWcGNwCb3H0xsCn+PJGvAo+nocyUNVSWAqgTWUSE9ITB5cBd8eW7gCuCNjKzs4D5wH+nocyUzSou\nZO7sYtrUTCQikpYwmO/ue+PL+4h94Z/AzELA14EvJnszM1trZq1m1tre3p6G6iXWWBnWhWciIkDh\neDYys4eBuoCXbhz+xN3dzDxgu88BD7h7m5mNWZa7rwPWAbS0tAS9V9o0VJbyavvxqSxCRGRGGFcY\nuPuaRK+Z2X4zq3f3vWZWDxwI2Owc4N1m9jmgDCg2s2PuPlb/wpRrrJzFz7cfxN1JFlIiIrksHc1E\nG4Br48vXAveO3MDdP+7uze6+kFhT0feyHQQQOzPo7o/Q2T2Q7aqIiGRVOsLgVuAiM9sOrIk/x8xa\nzOzONLz/lGmqGhpeqn4DEclv42omGou7dwAXBqxvBT4dsP67wHdTLTcd3rzwrLOHZY0VWa6NiEj2\n5O0VyKDbX4qIDMnrMJg7u5jSopCmpBCRvJfXYWBmNFSG2dOlMBCR/JbXYQCxpiKdGYhIvlMYVIbZ\nrfmJRCTP5X0YNFSGOXisj96BSLarIiKSNXkfBkMjivZ26exARPJX3oeBbnIjIqIwGHYVsm5yIyL5\nK+/DYH55KWaoE1lE8lreh0FxYYj5c0rVTCQieS3vwwBis5dqSgoRyWcKA6CxapZmLhWRvKYwIHZm\nsLerh2h0Sm+sJiIybSkMgKbKMAMRp/1YX7arIiKSFQoDoFE3uRGRPKcwQBeeiYgoDNBNbkREFAbA\nnNIi5pQWqplIRPKWwiCusTKsMwMRyVsKg7jGyjBt6jMQkTyVUhiY2Vwz22hm2+OPVQm2azaz/zaz\nbWb2opktTKXcqdBYpTMDEclfqZ4Z3ABscvfFwKb48yDfA77m7qcDK4EDKZabduf3PsID0c/hN1fC\nbctgy/psV0lEJGNSDYPLgbviy3cBV4zcwMyWAoXuvhHA3Y+5+/SaL3rLei545a9pCh3EcOjaBfdd\nr0AQkbyRahjMd/e98eV9wPyAbU4FOs3sbjN71sy+ZmYFKZabXptuoTAyYgrrgR7YdEt26iMikmGF\nyTYws4eBuoCXbhz+xN3dzIIm9ykE3g2sAN4AfgR8Evh2gvLWAmsBmpubk1UvPbraJrZeRCTHJA0D\nd1+T6DUz229m9e6+18zqCe4LaAM2u/vO+D4/BVaRIAzcfR2wDqClpSUzM8dVNMWahoLWi4jkgVSb\niTYA18aXrwXuDdjmKaDSzGriz98LvJhiuel14U1QFD5xXVE4tl5EJA+kGga3AheZ2XZgTfw5ZtZi\nZncCuHsE+CKwycyeBwz41xTLTa/lV8Gld9A3u5GoG93herj0jth6EZE8YO7Tdw7/lpYWb21tzVh5\nkajT8tcbuWBJLbddfWbGyhURSRcze9rdWya6n65AHqYgZLzn1Boee6WdiG50IyJ5RGEwwurTajl0\nvJ8tbZ3ZroqISMYoDEY4f3ENIYNHXpp2F0mLiEwZhcEIVbOLWdFcxSMvt2e7KiIiGaMwCLB6SQ3P\n7+7iwNHe5BuLiOQAhUGA1afVAvCYzg5EJE8oDAIsrS+ndk4JjyoMRCRPKAwCmBmrl9Ty+CvtDESi\n2a6OiMiUUxgksPq0Go72DfL064ezXRURkSmnMEjg3FOqKSowHnlZQ0xFJPcpDBKYU1rE2Qvn8uhL\n6jcQkdynMBjD6iW1vLz/KLt1b2QRyXEKgzGsPi0267auRhaRXKcwGMPJNWU0VYV5VP0GIpLjFAZj\nGBpi+ssdHfQORLJdHRGRKaMwSOK9p9XSMxDhydcOZbsqIiJTRmGQxKpF8ygpDGmIqYjkNIVBEuHi\nAs45eZ46kUUkpykMxmH1klp+09HNawePZ7sqIiJTQmEwDquXxGYx1dmBiOQqhcE4NM+bxck1s9Vv\nICI5S2EwTquX1PLEzkN09w9muyoiImmXchiY2Vwz22hm2+OPVQm2+3sz22pm28zsDjOzVMvOpNWn\n1dIfifLLHR3ZroqISNql48zgBmCTuy8GNsWfn8DM3gWcCywHlgFnA+9JQ9kZc/bCucwuLlBTkYjk\npHSEweXAXfHlu4ArArZxoBQoBkqAImB/GsrOmOLCEOctrubRlw7g7tmujohIWqUjDOa7+9748j5g\n/sgN3P1/gEeAvfG/h9x9WxrKzqjVS2rZ09XLK/uPZbsqIiJpVTiejczsYaAu4KUbhz9xdzezUT+b\nzewU4HSgKb5qo5m9291/HrDtWmAtQHNz83iqlzEXDA0xffkAS+rmZLk2IiLpM64zA3df4+7LAv7u\nBfabWT1A/DGoUf1K4NfufszdjwEPAuckKGudu7e4e0tNTc3k/qumSF1FKafXl/MzXW8gIjkmHc1E\nG4Br48vXAvcGbPMG8B4zKzSzImKdxzOumQhg9ZIann79MF09A9muiohI2qQjDG4FLjKz7cCa+HPM\nrMXM7oxv82PgVeB54DngOXe/Lw1lZ9x7T6slEnV+sf1gtqsiIpI24+ozGIu7dwAXBqxvBT4dX44A\nn0m1rOngzAWVVISLeOTlA3xweX22qyMikha6AnmCCgtCnH9qDY++3E40qiGmIpIbFAaTsHpJDQeP\n9fHCnq5sV0VEJC0UBpPwnlNrMINHXmrPdlVERNJCYTAJ88pKeEdTpaamEJGcoTCYpNVLanmurZOO\nY33ZroqISMoUBpO0+rQa3OHx7WoqEpGZT2EwScsaKqguK+Fn6jcQkRygMJikUMi4YEkNj7/SzmAk\nmu3qiIikRGGQgtVLaunqGWDzrs5sV0VEJCUKgxSs7n+UX5Zcz1nfXQS3LYMt67NdJRGRSUl5Ooq8\ntWU9sx76PLOsJ/a8axfcd31seflV2auXiMgk6MxgsjbdAgM9J64b6ImtFxGZYRQGk9XVNrH1IiLT\nmMJgsiqaJrZeRE60ZX2sr+3mysz0uU2mvMnWMdP7pYH6DCbrwptifQTDmop6KMHffSOzslgtkRlh\ny/oT//1MpM9ty/pYc2xXW+zH14U3jW+fiZY32ToG7Of3Xc/AYJTepR8hEnEGolEGIx77i0YZjDrh\nl35C4+M3EIpkpx/S3KfvNMwtLS3e2tqa7WokNuxD2V/WwP/uvILSFddw60eWZ7tmItPbbctiX3Yj\nVSyAz7+QeL+RX7QARWG49I6EX5jujt+2jNCR0U24vbMaePSSR+gbjNA7EKF3IErvQIS+wSjXPvEh\nKvr3jdrnYEEtf1r/A/ojUfoHY38DkSj9kSgDg1F+0reWekbf/KotWs15/Xck/E/7RfH1NIUCbpqV\n7JiMYGZPu3vLuHeI05lBKpZf9eYHsBiY/+A2vvXYTi47s4F3nVyd3bqJZMpkfqmPo8+tdyDCkZ4B\njvQO0NUzyJHeAd754E3MChi40bHhL/lC60K6+wc53heJPfZH6O4bpHsgwqvFbWCjiys+vpc//MHT\ngVW5rmRf4D5zI+109w9SXBhiTmkhJYUhigpCFMcf67Z2BL5fY6iDv/zg6RSGjIKCEEUho7AgRGHI\nKCwwGu8O3i9T/ZAKgzT6/JpT+a8X9vGlu5/noT89n9KigmxXSWRqjaMpZTAS5XD3AIeO99NxvI9D\nx/u5oLSOst69o95un1Xzob9+mCO9A/QPjr6yf2fJ3sAv6KrBA3T2DDC7uICGymJmlxQwq7iQ2cUF\nzCop5HhrPXP6Rpc3UNbA/Z85j9KigthfYYiS+GPojgWBZy+hiibu/ty5iY9JW1PgflbRxKffvSjx\nfpuC98tUP6TCII1Kiwr4uw+/nd/51yf4x4e3c8MHTst2lUTGbwK/8CNRp+NYH5X/fTPFAb/U2396\nI1dvrOXQ8X66egYY2Rp9WehKbi26k1nW/+a6Pivhwflruah2PhXhIsrDhZSXFlEeLqK8tJDycBGR\n9Y2Eju0eVZ9QRRP3/tEYX9DzbwlsXiq5+GbOaKgI3iegX5CicGz9WDK9X5ooDNLsXSdXc3XLAv71\n5zv50PJ6ljUm+KCJTCcBv/Aj917PM785zNMVa9jX1cv+I73sO9LLvq5eDhztIxJ1dpbsDvylPi/a\nzul15cydXczc2cXMKyt+a3l2CXNnr6Hk1TPhka++GT4lF97Ep5I1L73v5sl9YQ6970SasyazTzb2\nSxN1IE+Bru4B1tz2GLVzSrj3j86lsEAjeCWDkvzCj0ad/Ud7eb2jmzcOdbPrUDefevJS5g7uH/VW\nQ52eZSWF1FWUUldeyvzyUuoqSqgrL+W3f/4Bwt17Rtdhgp2e6fzvy3eT7UBWGEyRB5/fy2f/7Rm+\n9IHT+Mx7Ts52dSRfBIy2GQiV8tMFf879nMcbh7ppO9RD/7CZdkMGO0o+TojR3wWOcfxLBykrSdCI\nMInRPTK1sjKayMw+CtwMnA6sdPfAb24zez9wO1AA3Onut6ZS7kzwgbfXc/EZ8/mHja9w8Rl1LKye\nne0qyUyU5Ffw0d4BXm0/zvb9R9nRfow/aL2R6siJbfhF0V7Off0b3DXvbE6rm8NFS+fTPHfWm38N\nlWFCdyTu9EwYBJD1pg1Jn5TODMzsdCAKfAv4YlAYmFkB8ApwEdAGPAV8zN1fTPb+M/nMAGD/kV7W\nfP0xljVW8O9/8E7MAhpXJT+k40IpYDBUyr3Nf85PI+ey48Ax9nb1vvlacUGIl4o+FvgLHwxuHmOq\ndf3CzxlZOTNw923xwsfabCWww913xrf9IXA5kDQMZrr55aV86ZLT+Yt7nmd96y6uPrs521WSbJjA\nlazRqPNax3Fe3HOE8+//KypGjNQpjPay6rVv8N3qlZyzaB4n15axuLaMU2rLaJ47K+Ev/KTDE/UL\nP+9lYjRRIzD809kGvDPRxma2FlgL0Nw88788rzl7Afdu3s3f3L+N1UtqqS0vzXaVJNMSzHDrm77C\n1nkXs3VPF1v3HGHrniNs23uE7v4IADsTXPTUYB3c98fnBZeVyvDEYRdRSv5JGgZm9jBQF/DSje5+\nb7or5O7rgHUQayZK9/tnWihk/N2H3877b/85N9+3lW9+/KxsV0kyLcEVpN65mw/90y8AmF1cwNKG\ncq5qWcDShnLOaCjHftQUuK+N9Stfv/BlkpKGgbuvSbGM3cCCYc+b4uvyxqKaMv7kwsV87aGXeWjr\nPi4+IyhbZUYYR9u/u/Objm6efeMwz77RyR+HqqmNto96q6Ml8/nnj6zgjIYK3jZ3FqHQiNOAC788\n+TH1+vKXCcpEM9FTwGIzO4lYCFwD/E4Gyp1W1p6/iP/cspe/+ukLrFo0j4pwUbarJBOVoO2/uz9C\na/kann2jk2d3HWbzrk46uweA2C/++XN/j88cuZ2i6FudvRSFqfjQV/nQ8obE5elXvmRQqqOJrgT+\nCagBOoHN7n6xmTUQG0J6SXy7S4B/JDa09Dvu/jfjef+ZPppopC1tnVzxjV9yzcpm/vbKt2e7OjJR\nCWbaHLowywwW15axYkEVK5orWdFcxSm1ZRSETBdKScboorMZ4m8f2Ma6x3fyw7WrWLVoXrarI0n0\nD0Z5fncnT752mD989CwswYVZv/rEDpY3VTCnVGd8kl2awnqG+PyaUxl89kcs/P6f4H4w1hmoX4mZ\nl+CX+rG+QZ5+/TCtvznEk68dYvOuTvris2deGa6mzke3/VtFE+eeoinLZWZTGGRY+KWfcGP0Xyjw\n7NzNSAhs+++/5zpuf+gl/u+hs4g6FISMMxrK+cSqt3H2wipaFs6leuffZnVWSZGppDDItE23UBAZ\nPeacTbcoDDLgwJFeyh788qgbpBR7H5/s/T4Fq6/m7JPmsqK5avQ0DOrQlRymMMi0RGPOu9qCri+S\nZJJ0zO7r6uWJ1zr49c4Onth5iJ0Hj7OzZE/gxVw1kXa+8L4lY5enYZuSoxQGmVYRPF3Abp/H9x/c\nxufXnKo7pI1XQHNPdMP1PP2bQ/y4/1088VoHv+noBmBOaSErF87lYyubGXyykeKAG6Rk6o5SItOR\nwiDTAqYL8MIwv6j/LN96bCc/23aAr1/1DpY3VWaxkjODb7oFG9HcExrsob71azwY+iYrT5rHJ1a9\njVWL5nF6fXlsiCdA5c1q+xcZQWGQaQHtznbhTVyz/CrqXj7ADT95niu/+Ss+d8HJ/PF7F1NcqBvj\nDHF3Xm0/xhOvxUb63Jagaa0x1MGzN73vrS//kdT2LzKKrjOYZrp6BvjKfVu5+5ndnF5fztc/+g6W\nNpRnu1pTL6DtP7Lso7y07whPxr/8n3ztEB3HY/fMrZlTwn/555gXcHeuKb3Llsg0p4vOcszGF/fz\npbufp6unn+vfu5g/vOBkirb+ODd/zQbMpd9nJdzka/lR7zkANFWFWXnSXN550lxWnjSPhfNmYc//\nh+bgFxlBYZCDDh/v56YNW7nvuT1cN+8ZvtD3DUKDufHF5+683tHN5l2dXPDAaioHRv/CP1w0n8cu\neYSzT5pLY2U4+I00zYPICRQGOez+LXtZcfd5NHBw9IvTsUkk4Av68MlXsLmtk81vdLJ5VyfPtb01\nmdvOko8TskncnUtERtF0FDnsg8vr8bs7Al/zrjY86qOnP86WLevxDddjg28N9+y9+zq+3P8sG6Ln\nETI4df4cLl5ax5nNlZy5oBL7YWPw9Rca6imSMQqDGcISXZ8QnccHv7qRMxdUvjlT5pkLKk+cInuy\nTSlj7Nc3GOGNju7YRVztx3nt4DFeO3ic2/d9iQZOHO5ZSh9/M+cePnbVF3l7U8XoK3snO2+/iKSN\nwmCmCLg+IVoYZteyL3JJtI5nXu/k9k3bGWr1O6W2jBULKrmy8Fes2vqVt/oaEsyFFI06A9EoAxFn\nYDBK6IX/YM7GPzthv/57ruM7j73Kv/esou1wN9FhLTvVZSUsqplNPcFnMHP69nHOyQlmadVQT5Gs\nU5/BTJLkF/7R3gG2tHXx7BuHeeaNTp594zD3DX6WptDovoY9VHMx32QgEguASPTEz8Eviq8P3G9/\nqIavnrKeRdWzWVRTxknVszmpZjblQ1M3J5jzf1r2bYjkIHUgyyjuDl+pSjgH/y1n/ZKighBFBRZ/\nfGv5kxtXBO6XtFM3YJjoTB71JDLTqANZRjGzhHMhWUUTX770jMQ7Pxm8X9JOXTX5iMxICoNcF9DX\nMK7O2cnuB5rZU2QG0sQ3uW75VbEmmooFgMUex9NkM9n9RGRGUp+BiEgOmWyfgc4MREQktTAws4+a\n2VYzi5pZYBKZ2QIze8TMXoxv+yeplCkiIumX6pnBC8CHgcfH2GYQ+DN3XwqsAv7IzJamWK6IiKRR\nSqOJ3H0bxIcwJt5mL7A3vnzUzLYBjcCLqZQtIiLpk9E+AzNbCKwAnshkuSIiMrakZwZm9jBQF/DS\nje5+73gLMrMy4CfAn7r7kTG2WwusjT89ZmYvj7eMGagagualzms6JsF0XEbTMRmtGnjbZHZMy9BS\nM3sU+KK7B44DNbMi4D+Bh9z9H1IuMEeYWetkhoDlMh2TYDouo+mYjJbKMZnyZiKLdSh8G9imIBAR\nmZ5SHVp6pZm1AecA95vZQ/H1DWb2QHyzc4H/BbzXzDbH/y5JqdYiIpJWqY4muge4J2D9HuCS+PIv\ngGlyG65pZ122KzAN6ZgE03EZTcdktEkfk2k9HYWIiGSGpqMQERGFQSaY2fvN7GUz22FmNwS8/kkz\nax/Wp/LpbNQzk8zsO2Z2wMwCb39mMXfEj9kWM/utTNcx08ZxTC4ws65hn5Ocv0n0eKazybfPyjiP\nycQ/K+6uvyn8AwqAV4FFQDHwHLB0xDafBP4523XN8HE5H/gt4IUEr18CPEisv2kV8ES26zwNjskF\nwH9mu54ZPib1wG/Fl+cArwT8+8mrz8o4j8mEPys6M5h6K4Ed7r7T3fuBHwKXZ7lOWefujwOHxtjk\ncuB7HvNroNLM6jNTu+wYxzHJO+6+192fiS8fBYamsxkurz4r4zwmE6YwmHqNwPD7R7YR/D/uI/FT\n3B+b2YLMVG1aG+9xyzfnmNlzZvagmY1x39LcM8Z0Nnn7WUkyxc+EPisKg+nhPmChuy8HNgJ3Zbk+\nMj09A7zN3d8B/BPw0yzXJ3M3lJMAAAE9SURBVGPGO51NPklyTCb8WVEYTL3dwPBf+k3xdW9y9w53\n74s/vRM4K0N1m86SHrd84+5H3P1YfPkBoMjMqrNcrSkXn87mJ8C/ufvdAZvk3Wcl2TGZzGdFYTD1\nngIWm9lJZlYMXANsGL7BiPbNy4i1Aea7DcDvxkeKrAK6PDYdet4ys7r49C6Y2Upi/347slurqTXO\n6Wzy6rMynmMymc9KSlcgS3LuPmhm1wEPERtZ9B1332pmtwCt7r4BuN7MLiN2I6BDxEYX5TQz+3/E\nRjxUx6c0+TJQBODu/wI8QGyUyA6gG/hUdmqaOeM4Jr8NfNbMBoEe4BqPDx3JYUPT2TxvZpvj6/4C\naIa8/ayM55hM+LOiK5BFRETNRCIiojAQEREUBiIigsJARERQGIiICAoDERFBYSAiIigMREQE+P/s\nes9znult7wAAAABJRU5ErkJggg==\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          }
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "XC1xaDwbtcxb",
-        "colab_type": "text"
-      },
-      "source": [
-        "今回は水素分子の原子の結合間の距離に応じて、各状態の安定エネルギーをVQEを用いて求めています。"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "3vw6h4eytfK2",
-        "colab_type": "text"
-      },
-      "source": [
-        "##2-3-3 中身確認\n",
-        "MoluculearDataというのでOpenFermionに最初から入っているデータを使えるようです。H2でSto-3g系を読み込んでみます。"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "U2xwZyAItaMu",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "def get_molecule(bond_len):\n",
-        "  geometry = [('H',(0.,0.,0.)),('H',(0.,0.,bond_len))]\n",
-        "\n",
-        "  description = format(bond_len)\n",
-        "  molecule = MolecularData(geometry, \"sto-3g\",1,description=description)\n",
-        "\n",
-        "  molecule.load()\n",
-        "  return molecule"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "jy8xNG4Etk2S",
-        "colab_type": "text"
-      },
-      "source": [
-        "原子間距離が0.4のものを読み込んで、ハミルトニアンと呼ばれる基本の式が取得できます。"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "TO1lSYvbtikE",
-        "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 646
-        },
-        "outputId": "51191d25-cec4-4d64-a0c5-99ddeebe83d8"
-      },
-      "source": [
-        "m = get_molecule(0.4)\n",
-        "m.get_molecular_hamiltonian()"
-      ],
-      "execution_count": 4,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "() 1.322943021475\n",
-              "((0, 1), (0, 0)) -1.4820918858979102\n",
-              "((1, 1), (1, 0)) -1.4820918858979102\n",
-              "((2, 1), (2, 0)) -0.1187350527865787\n",
-              "((3, 1), (3, 0)) -0.1187350527865787\n",
-              "((0, 1), (0, 1), (0, 0), (0, 0)) 0.36843967630348756\n",
-              "((0, 1), (0, 1), (2, 0), (2, 0)) 0.08225771204699692\n",
-              "((0, 1), (1, 1), (1, 0), (0, 0)) 0.36843967630348756\n",
-              "((0, 1), (1, 1), (3, 0), (2, 0)) 0.08225771204699692\n",
-              "((0, 1), (2, 1), (0, 0), (2, 0)) 0.082257712046997\n",
-              "((0, 1), (2, 1), (2, 0), (0, 0)) 0.3626667179796745\n",
-              "((0, 1), (3, 1), (1, 0), (2, 0)) 0.082257712046997\n",
-              "((0, 1), (3, 1), (3, 0), (0, 0)) 0.3626667179796745\n",
-              "((1, 1), (0, 1), (0, 0), (1, 0)) 0.36843967630348756\n",
-              "((1, 1), (0, 1), (2, 0), (3, 0)) 0.08225771204699692\n",
-              "((1, 1), (1, 1), (1, 0), (1, 0)) 0.36843967630348756\n",
-              "((1, 1), (1, 1), (3, 0), (3, 0)) 0.08225771204699692\n",
-              "((1, 1), (2, 1), (0, 0), (3, 0)) 0.082257712046997\n",
-              "((1, 1), (2, 1), (2, 0), (1, 0)) 0.3626667179796745\n",
-              "((1, 1), (3, 1), (1, 0), (3, 0)) 0.082257712046997\n",
-              "((1, 1), (3, 1), (3, 0), (1, 0)) 0.3626667179796745\n",
-              "((2, 1), (0, 1), (0, 0), (2, 0)) 0.36266671797967454\n",
-              "((2, 1), (0, 1), (2, 0), (0, 0)) 0.08225771204699726\n",
-              "((2, 1), (1, 1), (1, 0), (2, 0)) 0.36266671797967454\n",
-              "((2, 1), (1, 1), (3, 0), (0, 0)) 0.08225771204699726\n",
-              "((2, 1), (2, 1), (0, 0), (0, 0)) 0.08225771204699728\n",
-              "((2, 1), (2, 1), (2, 0), (2, 0)) 0.38272169831413727\n",
-              "((2, 1), (3, 1), (1, 0), (0, 0)) 0.08225771204699728\n",
-              "((2, 1), (3, 1), (3, 0), (2, 0)) 0.38272169831413727\n",
-              "((3, 1), (0, 1), (0, 0), (3, 0)) 0.36266671797967454\n",
-              "((3, 1), (0, 1), (2, 0), (1, 0)) 0.08225771204699726\n",
-              "((3, 1), (1, 1), (1, 0), (3, 0)) 0.36266671797967454\n",
-              "((3, 1), (1, 1), (3, 0), (1, 0)) 0.08225771204699726\n",
-              "((3, 1), (2, 1), (0, 0), (1, 0)) 0.08225771204699728\n",
-              "((3, 1), (2, 1), (2, 0), (3, 0)) 0.38272169831413727\n",
-              "((3, 1), (3, 1), (1, 0), (1, 0)) 0.08225771204699728\n",
-              "((3, 1), (3, 1), (3, 0), (3, 0)) 0.38272169831413727"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 4
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "MCcUSNvltukv",
-        "colab_type": "text"
-      },
-      "source": [
-        "こちらはパウリ行列の表現ではないので、今回VQEで計算できるように変換をします。"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "sP1KphQktw8Z",
-        "colab_type": "text"
-      },
-      "source": [
-        "##2-3-4 量子コンピュータ向け変換\n",
-        "Bravi-Kitaev(ブラビキタエフ)変換やJordan–Wigner(ジョルダンウィグナー)変換がありますが、今回は前者のBK変換をして確認してみると、"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "3B3loOfutn2j",
-        "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 272
-        },
-        "outputId": "99f7f869-64b7-4297-ac30-52d52b4147ff"
-      },
-      "source": [
-        "h = bravyi_kitaev(get_fermion_operator(m.get_molecular_hamiltonian()))\n",
-        "print(h)"
-      ],
-      "execution_count": 7,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "(0.7407724940116754+0j) [] +\n",
-            "(0.041128856023498556+0j) [X0 Z1 X2] +\n",
-            "(0.041128856023498556+0j) [X0 Z1 X2 Z3] +\n",
-            "(0.041128856023498556+0j) [Y0 Z1 Y2] +\n",
-            "(0.041128856023498556+0j) [Y0 Z1 Y2 Z3] +\n",
-            "(0.23528824284103544+0j) [Z0] +\n",
-            "(0.23528824284103542+0j) [Z0 Z1] +\n",
-            "(0.18133335898983727+0j) [Z0 Z1 Z2] +\n",
-            "(0.18133335898983727+0j) [Z0 Z1 Z2 Z3] +\n",
-            "(0.14020450296633868+0j) [Z0 Z2] +\n",
-            "(0.14020450296633868+0j) [Z0 Z2 Z3] +\n",
-            "(0.18421983815174378+0j) [Z1] +\n",
-            "(-0.45353118471995524+0j) [Z1 Z2 Z3] +\n",
-            "(0.19136084915706864+0j) [Z1 Z3] +\n",
-            "(-0.45353118471995524+0j) [Z2]\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "xWER997LuB9V",
-        "colab_type": "text"
-      },
-      "source": [
-        "このようにきちんと変換されました。ちょっと複雑な形をしていますが、これこそがこれまで学んできたパウリ行列の和で書かれたハミルトニアンです。これをVQEにかけますが、今回はUCC理論と呼ばれる上記のハミルトニアンに対応するansatzがあるため効率的に計算ができます。"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "97RcOB7Rt4_7",
-        "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 714
-        },
-        "outputId": "730c7fd9-0eed-4349-edd0-24aae9f26ba5"
-      },
-      "source": [
-        "runner = vqe.Vqe(UCCAnsatz(h,2,Circuit().x[0]))\n",
-        "result = runner.run(verbose = True)"
-      ],
-      "execution_count": 8,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "params: [0.05292822 0.69293649] val: -0.5142646866048539\n",
-            "params: [0.05292822 0.69293649] val: -0.5142646866048539\n",
-            "params: [1.05292822 0.69293649] val: 0.8011773974437459\n",
-            "params: [-1.56510578  0.69293649] val: -0.391150390234131\n",
-            "params: [0.05292822 0.69293649] val: -0.5142646866048539\n",
-            "params: [-0.56510575  0.69293649] val: -0.8977304830394611\n",
-            "params: [-0.56510575  0.69293649] val: -0.8977304830394611\n",
-            "params: [-0.56510575  1.69293649] val: 1.1263433928808557\n",
-            "params: [-0.56510575 -0.92509751] val: -0.3739824457207399\n",
-            "params: [-0.56510575  0.69293649] val: -0.8977304830394611\n",
-            "params: [-0.56510575  0.07490252] val: -0.6645405398129258\n",
-            "params: [-0.56510575  1.07490249] val: 0.6502494968493011\n",
-            "params: [-0.56510575  0.42650545] val: -0.3371306326723218\n",
-            "params: [-0.56510575  0.83883452] val: -0.5188368945182854\n",
-            "params: [-0.56510575  0.5911689 ] val: -0.723006612107723\n",
-            "params: [-0.56510575  0.74866458] val: -0.8515651952459188\n",
-            "params: [-0.56510575  0.69517091] val: -0.8981969317962648\n",
-            "params: [-0.56510575  0.70634301] val: -0.897747129510898\n",
-            "params: [-1.18313973  0.69740533] val: -0.746229241629738\n",
-            "params: [-0.56510575  0.69517091] val: -0.8981969317962648\n",
-            "params: [-1.18313973  0.69740533] val: -0.746229241629738\n",
-            "params: [0.43489423 0.69155555] val: -0.0675824851807392\n",
-            "params: [-0.56510575  0.69517091] val: -0.8981969317962648\n",
-            "params: [-0.18313976  0.69378997] val: -0.7188123204271055\n",
-            "params: [-0.80117372  0.69602439] val: -0.9049963420733075\n",
-            "params: [-0.80117372  0.69602439] val: -0.9049963420733075\n",
-            "params: [-0.80117372  1.69602439] val: 1.2621240755027043\n",
-            "params: [-0.80117372 -0.92200961] val: -0.291223954836067\n",
-            "params: [-0.80117372  0.69602439] val: -0.9049963420733075\n",
-            "params: [-0.80117372  0.07799041] val: -0.4433620633023846\n",
-            "params: [-0.80117372  1.07799039] val: 0.9809286764492423\n",
-            "params: [-0.80117372  0.45270877] val: -0.11675869413404844\n",
-            "params: [-0.80117372  0.84192241] val: -0.44127255704023494\n",
-            "params: [-0.80117372  0.60308609] val: -0.6771437588686717\n",
-            "params: [-0.80117372  0.75175247] val: -0.8578763018840084\n",
-            "params: [-0.80117372  0.70482634] val: -0.9083099960106484\n",
-            "params: [-0.80117372  0.70482634] val: -0.9083099960106484\n",
-            "params: [-1.03724168  0.70567982] val: -0.837079229404281\n",
-            "params: [-0.41920772  0.7034454 ] val: -0.8514285285577546\n",
-            "params: [-0.80117372  0.70482634] val: -0.9083099960106484\n",
-            "params: [-0.65527569  0.70429887] val: -0.9117470824158458\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "pogBuf8HuG9y",
-        "colab_type": "text"
-      },
-      "source": [
-        "最適化のプロセスが出てきました。パラメータが最適化されながら最小基底状態が探索されています。今回はansatzは量子化学の理論に基づいて電子の配置をするUCCansatzと呼ばれるものが利用されました。通常ansatzの構成は難しいので、理論的な探究が求まれます。最小エネルギーは、"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "7aogyg6YuD6S",
-        "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        },
-        "outputId": "48520c01-5ad1-4d42-fc6c-ccf395d1df9b"
-      },
-      "source": [
-        "runner.ansatz.get_energy(result.circuit,runner.sampler)"
-      ],
-      "execution_count": 10,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "-0.9117470824158458"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 10
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gFgZVsk6uMXf",
-        "colab_type": "text"
-      },
-      "source": [
-        "原子間距離0.4の場合の最小値の期待値が求まりました。これを全体でやったのが最初のコードです。再掲します。"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "uP2XQ8j3uJnr",
-        "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 283
-        },
-        "outputId": "83f553f0-957b-4660-b275-4e56a1ef0ab2"
-      },
-      "source": [
-        "from blueqat import *\n",
-        "from openfermion import *\n",
-        "from openfermionblueqat import*\n",
-        "import numpy as np\n",
-        "\n",
-        "def get_molecule(bond_len):\n",
-        "  geometry = [('H',(0.,0.,0.)),('H',(0.,0.,bond_len))]\n",
-        "\n",
-        "  description = format(bond_len)\n",
-        "  molecule = MolecularData(geometry, \"sto-3g\",1,description=description)\n",
-        "\n",
-        "  molecule.load()\n",
-        "  return molecule\n",
-        "\n",
-        "x = [];e=[];fullci=[]\n",
-        "for bond_len in np.arange(0.2,2.5,0.1):\n",
-        "  m = get_molecule(\"{:.2}\".format(bond_len))\n",
-        "  h = bravyi_kitaev(get_fermion_operator(m.get_molecular_hamiltonian()))\n",
-        "  runner = vqe.Vqe(UCCAnsatz(h,6,Circuit().x[0]))\n",
-        "  result = runner.run()\n",
-        "  x.append(bond_len)\n",
-        "  e.append(runner.ansatz.get_energy(result.circuit,runner.sampler))\n",
-        "  fullci.append(m.fci_energy)\n",
-        "\n",
-        "%matplotlib inline\n",
-        "import matplotlib.pyplot as plt\n",
-        "plt.plot(x,fullci)\n",
-        "plt.plot(x,e,\"o\")"
-      ],
-      "execution_count": 11,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "[<matplotlib.lines.Line2D at 0x7fd876809668>]"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 11
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYMAAAD5CAYAAADFqlkBAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0\ndHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nO3de3hc1X3u8e9vdB1blmRbknWzMAZj\nMMSBIhwTCMHBBELDLU2AXE5IW+o2KaFNm+ccUrcESNvQ5klpaJKTuCRPyKUncRIuppgS43BJ0gYQ\nYAzGgMEOWL7KsiVfdJ/5nT9mhGVpj0bWjGakmffzPHpmz549sxab8bx7r732WubuiIhIfgtluwIi\nIpJ9CgMREVEYiIiIwkBERFAYiIgICgMREQEK0/EhZnYp8DWgALjb3e8Y9vpfATcAA0Ab8Efu/may\nz62qqvJ58+alo4oiInnh2Wef3efu1cf7vpTDwMwKgG8AFwOtwDNmtsbdXx6y2fNAs7t3mdmngX8G\nrk322fPmzaOlpSXVKoqI5A0zS3qgHSQdzURLgNfdfau79wE/Bq4cuoG7P+buXfGnvwUa01CuiIik\nSTrCoAHYPuR5a3xdIn8MPJyGckVEJE3Scs1grMzsE0Az8N5RtlkBrABoamrKUM1ERPJbOs4MdgBz\nhzxvjK87hpktB1YCV7h7b6IPc/dV7t7s7s3V1cd9DURERMYhHWHwDLDAzE40s2LgOmDN0A3M7Czg\n28SCYG8ayhQRkTRKOQzcfQC4EXgE2AysdvdNZna7mV0R3+wrQBnwUzPbYGZrEnxc6jauhjvPgFsr\nY48bV09YUSIiuSIt1wzcfS2wdti6W4YsL09HOUltXA0P3gT93bHnndtjzwEWX5ORKoiITEW5dQfy\n+tuPBsGg/u7YehERSSi3wqCz9fjWi4gIkGthUJHgXrZE60VEBMi1MLjoFigKH7uuKBxbLyIiCeVW\nGCy+Bi6/i46iOUQxqJgLl9+li8ciIklk9A7kjFh8DT85cDZffvgVNt78fspLi7JdIxGRSS+3zgzi\nGmbGmop2dnQn2VJERCBHw6C+UmEgInI8cjIMGuNhsOOAwkBEZCxyMgyqykooLgixo6Mn21UREZkS\ncjIMQiGjrrKUHWomEhEZk5wMA4D6irCuGYiIjFHOhkHDzLCuGYiIjFHOhkF9ZZg9h3roj0SzXRUR\nkUkvZ8OgsTKMO+zu1EVkEZFkcjYMBu810EVkEZHkcjYMBu9C1nUDEZHkcjYM6ipKAZ0ZiIiMRc6G\nQWlRAVVlJepeKiIyBjkbBhDvXqowEBFJKrfDQHchi4iMSY6HQewuZHfPdlVERCa1tISBmV1qZq+a\n2etmdnPA6yVm9pP460+Z2bx0lJtMfWWYnv4o+4/0ZaI4EZEpK+UwMLMC4BvAB4BFwEfNbNGwzf4Y\nOODuJwN3Av+Uarlj0aB7DURExiQdZwZLgNfdfau79wE/Bq4cts2VwD3x5Z8BF5mZpaHsUWmSGxGR\nsUlHGDQA24c8b42vC9zG3QeATmB20IeZ2QozazGzlra2tpQq1hi/8axVN56JiIxq0l1AdvdV7t7s\n7s3V1dUpfVZFuIhpxQXs1CQ3IiKjSkcY7ADmDnneGF8XuI2ZFQIVQHsayh6VmdFQGWZHR9dEFyUi\nMqWlIwyeARaY2YlmVgxcB6wZts0a4Pr48oeBX3qG+nvWV4Z1ZiAikkTKYRC/BnAj8AiwGVjt7pvM\n7HYzuyK+2XeA2Wb2OvBXwIjupxNFdyGLiCRXmI4Pcfe1wNph624ZstwDfCQdZR2vhsow+4/00d0X\nIVxckI0qiIhMepPuAnK66V4DEZHkcj4MdK+BiEhyOR8Gb09yozAQEUko58NgzowSCkKmGc9EREaR\n82FQWBCitrxUzUQiIqPI+TAAqK8spVVhICKSUF6EweC8BiIiEiwvwqC+Mszuzh4iUU1yIyISJC/C\noGFmmIGos/eQhqUQEQmSH2EweOOZehSJiATKrzDQdQMRkUB5EQb1CgMRkVHlRRhMLymkclqRehSJ\niCSQF2EAsaYiXTMQEQmWN2GgSW5ERBLLmzCITX/ZTYYmWBMRmVLyKgwO9w5wsGcg21UREZl08icM\nZupeAxGRRPImDNS9VEQksbwJgwbNeCYiklDehMHs6cUUF4Z0ZiAiEiClMDCzWWa2zsy2xB9nBmxz\nppn9j5ltMrONZnZtKmWOVyhkb/coEhGRY6V6ZnAzsN7dFwDr48+H6wI+6e6nA5cC/2pmlSmWOy71\nlaW6gCwiEiDVMLgSuCe+fA9w1fAN3P01d98SX94J7AWqUyx3XDTJjYhIsFTDYI6774ov7wbmjLax\nmS0BioE3Uix3XOorw+w91EvvQCQbxYuITFqFyTYws0eB2oCXVg594u5uZglv7zWzOuAHwPXuHh1l\nuxXACoCmpqZk1Tsugz2Kdnf2cMLs6Wn9bBGRqSxpGLj78kSvmdkeM6tz913xH/u9CbYrBx4CVrr7\nb5OUtwpYBdDc3JzWsSOGTnKjMBAROSrVZqI1wPXx5euBB4ZvYGbFwH3A9939ZymWl5K370LWdQMR\nkWOkGgZ3ABeb2RZgefw5ZtZsZnfHt7kGuAD4lJltiP+dmWK541JbUQooDEREhkvaTDQad28HLgpY\n3wLcEF/+IfDDVMpJl5LCAmpmlKhHkYjIMHlzB/Kget14JiIyQt6FQcNMTXIjIjJc3oVBY/zMIBrV\nJDciIoPyLgzqK8P0DURpP9KX7aqIiEwaeRcGDZrXQERkhLwLg/pKzXgmIjJc3oXB4I1n6l4qInJU\n3oVBeWkhZSWFaiYSERki78LATJPciIgMl3dhAJrkRkRkuLwMg4aZYXZ2KgxERAblZRjUV4bp6Orn\nSO9AtqsiIjIp5GUYDN5roB5FIiIxeR0GrQoDEREgX8NA9xqIiBwjL8OgZkYphSFTjyIRkbi8DIOC\nkFFbUaozAxGRuLwMA9AkNyIiQ+VtGDRWapIbEZFBeRsG9ZVhdh/sYSASzXZVRESyLm/DoGFmmEjU\n2XOoN9tVERHJurwNA81rICJyVMphYGazzGydmW2JP84cZdtyM2s1s6+nWm6qjs541pXlmoiIZF86\nzgxuBta7+wJgffx5Il8CnkxDmSk7OiSFLiKLiKQjDK4E7okv3wNcFbSRmZ0NzAF+kYYyUxYuLmDW\n9GJa1UwkIpKWMJjj7rviy7uJ/eAfw8xCwFeBzyf7MDNbYWYtZtbS1taWhuol1lAZ1o1nIiJA4Vg2\nMrNHgdqAl1YOfeLubmYesN1ngLXu3mpmo5bl7quAVQDNzc1Bn5U29ZWlvNF2ZCKLEBGZEsYUBu6+\nPNFrZrbHzOrcfZeZ1QF7AzY7F3iPmX0GKAOKzeywu492fWHCNVRO41db9uHuJAspEZFclo5mojXA\n9fHl64EHhm/g7h939yZ3n0esqej72Q4CiJ0ZdPVF6Ojqz3ZVRESyKh1hcAdwsZltAZbHn2NmzWZ2\ndxo+f8I0zhzsXqrrBiKS38bUTDQad28HLgpY3wLcELD+e8D3Ui03Hd6+8ayjmzMaKrJcGxGR7Mnb\nO5BB01+KiAzK6zCYNb2Y0qKQhqQQkbyX12FgZtRXhtnZqTAQkfyW12EAsaYinRmISL5TGFSG2aHx\niUQkz+V9GNRXhtl3uJee/ki2qyIikjV5HwaDPYp2dersQETyV96HgSa5ERFRGAy5C1mT3IhI/sr7\nMJhTXooZuogsInkt78OguDDEnBmlaiYSkbyW92EAsdFLNSSFiOQzhQHQMHOaRi4VkbymMCB2ZrCr\ns5todEInVhMRmbQUBkBjZZj+iNN2uDfbVRERyQqFAdCgSW5EJM8pDNCNZyIiCgM0yY2IiMIAmFFa\nxIzSQjUTiUjeUhjENVSGdWYgInlLYRDXUBmmVdcMRCRPpRQGZjbLzNaZ2Zb448wE2zWZ2S/MbLOZ\nvWxm81IpdyI0zNSZgYjkr1TPDG4G1rv7AmB9/HmQ7wNfcffTgCXA3hTLTbsLeh5jbfQz+K2VcOcZ\nsHF1tqskIpIxqYbBlcA98eV7gKuGb2Bmi4BCd18H4O6H3X1yjRe9cTUXvvb3NIb2YTh0bocHb1Ig\niEjeSDUM5rj7rvjybmBOwDanAB1mdq+ZPW9mXzGzghTLTa/1t1MYGTaEdX83rL89O/UREcmwwmQb\nmNmjQG3ASyuHPnF3N7OgwX0KgfcAZwFvAT8BPgV8J0F5K4AVAE1NTcmqlx6drce3XkQkxyQNA3df\nnug1M9tjZnXuvsvM6gi+FtAKbHD3rfH33A8sJUEYuPsqYBVAc3NzZkaOq2iMNQ0FrRcRyQOpNhOt\nAa6PL18PPBCwzTNApZlVx5+/D3g5xXLT66JboCh87LqicGy9iEgeSDUM7gAuNrMtwPL4c8ys2czu\nBnD3CPB5YL2ZvQgY8O8plptei6+By++id3oDUTe6wnVw+V2x9SIiecDcJ+8Y/s3Nzd7S0pKx8iJR\np/nv13HhwhruvPbMjJUrIpIuZvasuzcf7/t0B/IQBSHjvadU88RrbUQ00Y2I5BGFwTDLTq1h/5E+\nNrZ2ZLsqIiIZozAY5oIF1YQMHntl0t0kLSIyYRQGw8ycXsxZTTN57NW2bFdFRCRjFAYBli2s5sUd\nnew91JN8YxGRHKAwCLDs1BoAntDZgYjkCYVBgEV15dTMKOFxhYGI5AmFQQAzY9nCGp58rY3+SDTb\n1RERmXAKgwSWnVrNod4Bnn3zQLarIiIy4RQGCZx3chVFBcZjr6qLqYjkPoVBAjNKizhn3iwef0XX\nDUQk9ykMRrFsYQ2v7jnEDs2NLCI5TmEwimWnxkbd1t3IIpLrFAajOKm6jMaZYR7XdQMRyXEKg1EM\ndjH9zevt9PRHsl0dEZEJozBI4n2n1tDdH+HpbfuzXRURkQmjMEhi6fzZlBSG1MVURHKawiCJcHEB\n5540WxeRRSSnKQzGYNnCGn7X3sW2fUeyXRURkQmhMBiDZQtjo5jq7EBEcpXCYAyaZk/jpOrpum4g\nIjlLYTBGyxbW8NTW/XT1DWS7KiIiaZdyGJjZLDNbZ2Zb4o8zE2z3z2a2ycw2m9ldZmaplp1Jy06t\noS8S5Tevt2e7KiIiaZeOM4ObgfXuvgBYH39+DDN7N3AesBg4AzgHeG8ays6Yc+bNYnpxgZqKRCQn\npSMMrgTuiS/fA1wVsI0DpUAxUAIUAXvSUHbGFBeGOH9BFY+/shd3z3Z1RETSKh1hMMfdd8WXdwNz\nhm/g7v8DPAbsiv894u6b01B2Ri1bWMPOzh5e23M421UREUmrwrFsZGaPArUBL60c+sTd3cxGHDab\n2cnAaUBjfNU6M3uPu/8qYNsVwAqApqamsVQvYy4c7GL66l4W1s7Icm1ERNJnTGcG7r7c3c8I+HsA\n2GNmdQDxx6BG9auB37r7YXc/DDwMnJugrFXu3uzuzdXV1eP7r5ogtRWlnFZXzi91v4GI5Jh0NBOt\nAa6PL18PPBCwzVvAe82s0MyKiF08nnLNRADLFlbz7JsH6Ozuz3ZVRETSJh1hcAdwsZltAZbHn2Nm\nzWZ2d3ybnwFvAC8CLwAvuPuDaSg74953ag2RqPPrLfuyXRURkbQZ0zWD0bh7O3BRwPoW4Ib4cgT4\n01TLmgzOnFtJRbiIx17dy+8vrst2dURE0kJ3IB+nwoIQF5xSzeOvthGNqoupiOQGhcE4LFtYzb7D\nvby0szPbVRERSQuFwTi895RqzOCxV9qyXRURkbRQGIzD7LIS3tlYqaEpRCRnKAzGadnCGl5o7aD9\ncG+2qyIikjKFwTgtO7Uad3hyi5qKRGTqUxiM0xn1FVSVlfBLXTcQkRygMBinUMi4cGE1T77WxkAk\nmu3qiIikRGGQgmULa+js7mfD9o5sV0VEJCUKgxQs63uc35TcxNnfmw93ngEbV2e7SiIi45LycBR5\na+Nqpj3yOaZZd+x553Z48KbY8uJrslcvEZFx0JnBeK2/Hfq7j13X3x1bLyITZ+Pq2Jn4rZU6I08j\nnRmMV2fr8a0XkdRtXB07A+/XGXm66cxgvCoaj2+9iKQulTPy8ZxRjPcsJNPvSwOdGYzXRbcce4QC\ndFOCv2cl07JYLZGcNt4z8vGcUYz3LCTgff7gTfQPROlZ9AdEIk5/NMpAxGN/0SgDUSf8ys9pePJm\nQpHsnPUoDMZr8H/O+tuhs5W+snq+0HEVpW+ezh3N2a2ayJSwcfXb/36oaIwdYCX70atojP1IBq1P\nwN3xR28jFHBG0fNfX+Tx0AX0DkTo6Y/Q0x+lpz9C70CU65/6OyoC3rPvgZX85dMn0BeJ0jcQ++uP\nROmLROkfiPLz3i9Qx7Hvs/5u9t6/kvNXJ547/dfFXyIUSnDWozCY5BZf8/b/pGJgzsOb+fYTW7ni\nzHrefVJVdusmkinj+VEfw1F3T3+Eg939HOzpp7N7gIM9/cw4+bOc+fwtFEZ73v6oPivhR6Wf5PHv\nPk1X3wBHeiOxx74IXb0DdPVHeKO4FWxkNYqP7OLPfvhsYBVvLNkd+J5ZkTa6+gYoLgwxo7SQksIQ\nRQUhiuOPtZvaAz+vIdTO3/7+aRSGjIKCEEUho7AgRGHIKCwwGu4Nfl+mrkMqDNLoc8tP4b9e2s0X\n7n2RR/7yAkqLCrJdJZGJNYYf9YFIlANd/ew/0kf7kV72H+njwrW3UBZw1L37vr/hg2tmcbCnn76B\noDv7G7ki9Ef878LV1Fs7u2023w59gt90v4vp0X6mFxdQX1nM9JICphUXMr24gGklhRxpqWNG764R\nn9ZfVs9Df3o+pUUFsb/CECXxx9BdcwPPQkIVjdz7mfMS75PW4LMXq2jkhvfMT/y+9cd/1pNOCoM0\nKi0q4Msfegcf+/en+NdHt3DzB07NdpVExu44jvAjUaf9cC+Vv7iV4oAf9bb7V3Ltuhr2H+mjs7sf\nHzYp4NaSXYFH3XN8HxcvmkNFuIjycCHlpUWUh4soLy2MPxZRHr6I8tK/J1RUQD1w21j+2+bcPuIa\nH0VhSi65ldPrK4LfE3BdkKJwbP1oMv2+NFEYpNm7T6ri2ua5/PuvtvLBxXWc0ZDgiyYymQQc4Uce\nuInnfneAZyuWs7uzhz0He9h9sIfdnT3sPdRLJOpsLdkR+KM+O9rGabXlzJpezKzpxcwuKz66PL0E\n/1EjHBrZ/GEVjXz5Q+9I/3/fsGt8Y2rOGs97svG+NDEfHtmTSHNzs7e0tGS7Gsets6uf5Xc+Qc2M\nEh748/MoLFAPXsmgJEf40aiz51APb7Z38db+Lrbv7+IPn76cWQN7RnxUa7SK8/vuoqykkNqKUmrL\nS5lTXkptRQm15aV8+FcfINy1c2QdKubC514avY5BR8GX36X7BVJkZs+6+3F3Y9GZwQSomFbE7Vec\nzqd/9Bzf+fU2/vS9J2W7SpIvAo7w++//LPc/28pDnM9b+7to3d9N35CRdkMGnysJnrWvIdTOS7dd\nQllJgp+K6beNr2kjy0fBMlJKYWBmHwFuBU4Dlrh74GG8mV0KfA0oAO529ztSKXcq+MA76rjk9Dn8\ny7rXuOT0WuZVTc92lWQqSnKUf6innzfajrBlzyFebzvMn7SspCpybBt+UbSH8978BvfMPodTa2dw\n8aI5NM2a9vZffWWY0F2JL3omDAJI7Ud9SG88yb6UmonM7DQgCnwb+HxQGJhZAfAacDHQCjwDfNTd\nX072+VO1mWjQnoM9LP/qE5zRUMF//Mm7MAtoXBVJJKApZSBUygNN/4f7I+fx+t7D7Oo82sWyuCDE\nK0UfJUTQv2mDW0cZal3NNjkjK81E7r45Xvhomy0BXnf3rfFtfwxcCSQNg6luTnkpX7jsNP7mvhdZ\n3bKda89pynaVJFvG2FMnGnW2tR/h5Z0HueChkTc9FUZ7WLrtG3yvagnnzp/NSTVlLKgp4+SaMppm\nTUt4hJ+0e6KabfJeJq4ZNABDv52twLsSbWxmK4AVAE1NU//H87pz5vLAhh38w0ObWbawhpry0mxX\nSTItQV/8/miUV6s/wKadnWzaeZBNOw+yeddBuvoiAGxNcNNTvbXz4GfPDy4rle6JarbJa0nDwMwe\nBWoDXlrp7g+ku0LuvgpYBbFmonR/fqaFQsaXP/QOLv3ar7j1wU188+NnZ7tKkmkJBlfbe99KPtgb\nG55genEBi+rLuaZ5Lovqyzm9vhz7SWPg3ac22lG+jvBlnJKGgbsvT7GMHcDcIc8b4+vyxvzqMv7i\nogV85ZFXeWTTbi45PShbZUoYQ3OPu/O79i6ef+sAz7/VwW2drYHDA9dbO1//2FmcXl/BCbOmEQoN\nOw246Ivj76mjH385TploJnoGWGBmJxILgeuAj2Wg3EllxQXz+c+Nu/i7+19i6fzZVISLsl0lOV4J\nmnu6+iK0lC/n+bc6eH77ATZs76Cjqx+IHfHfVFRNdWRk102raOSDi+sTl6ejfMmgVHsTXQ38G1AN\ndAAb3P0SM6sn1oX0svh2lwH/Sqxr6Xfd/R/G8vlTvTfRcBtbO7jqG7/huiVN/OPVE3CXpUysO88I\nvDg7eGOWGSyoKeOsuTM5q6mSs5pmcnJNGQUv/VQ9dSRjstWb6D7gvoD1O4HLhjxfC6xNpaxcsLix\nkhveM59VT27linfWs3T+7GxXSZLoG4jy4o4Ont52gD/rbA26nktDqJ0f3fAuFjdWMKM04IxPR/gy\nBegO5Az73PJTGHj+J8z7wV/gvi92MVA/DJmXoO3/cO8Az755gJbf7efpbfvZsL2D3vjomVeHq6j1\nthEfZRWNnHdykiHL1Y4vk5zCIMPCr/ycldFvUeCawzVrAtr+++67ka898gr/d//ZRB0KQsbp9eV8\nYukJnDNvJs3zZlG19R+zOqqkyERSGGTa+tspiGRvNqN8t/dgD2UPf5Fpw7p6Fnsvn+r5AQXLruWc\nE2dxVtPMkcMwqLlHcpjCINMSzFrkCdqjJYkkXT13d/bw1LZ2fru1nae27mfrviNsLdkZeDNXdaSN\nv3r/wtHLU3OP5CiFQaYlmMN1h8/mBw9v5nPLT9EMaWMV0NwTXXMTz/5uPz/rezdPbWvnd+1dAMwo\nLWTJvFl8dEkTA083UHw44FaXDM0oJTIZKQwyLWC4AC8M8+u6T/PtJ7byy817+eo172RxY2UWKzk1\n+PrbsWHNPaGBbupavsLDoW+y5MTZfGLpCSydP5vT6sopGLypq/JWtf2LDKMwyLSAdme76BauW3wN\nta/u5eafv8jV3/xvPnPhSXz2fQsoLtTEOIPcnTfaDvPUtlhPnztH6er5/C3vP/rjP5za/kVG0Exn\nk0xndz+3PbiJe5/bwWl15Xz1I+9kUX15tqs18QLa/iNnfIRXdh/k6fiP/9Pb9tN+pA+A6hkl/Jd/\nhtkBs3MlnWVLJIeN96YzhcEkte7lPXzh3hfp7O7jpvct4M8uPImiXJ0+M2As/V4r4RZfwU96zgWg\ncWaYJSfO4l0nzmLJibOZN3sa9qLu7BUZTmGQgw4c6eOWNZt48IWdvKOhglVnbqWu5Z9zomnD3Xmz\nvYsN2zu4cO0yKvtHHuEfKJrDE5c9xjknzqKhMhz8QWOcJ0AkXygMcthDG3fxm/u+yd9Gv8U06zv6\nwmQ9Cg74gT5w0lVsaO1gw1sdbNjewQutRwdz21rycUI2jtm5RGSErIxNJJnx+4vruHTdvRQc6jv2\nhf5u+n9xKwVnfGTk8MfZsnE1vuYmbOBod8+ee2/ki33PsyZ6PiGDU+bM4JJFtZzZVMmZcyuxHzcE\n33+hrp4iGaMwmCIKDgVPAVFwaCdnfWkdZ86tfHukzDPnVh47RPZ4m1JGeV/vQIS32rtiN3G1HWHb\nvsNs23eEr+3+AvUc292zlF7+YcZ9fPSaz/OOxoqRd/aOd9x+EUkbhcFUkeBmte5ptVy2oJbn3uzg\na+u3MNjqd3JNGWfNreTqwv9m6abbCA2MPhZSNOr0R6P0R5z+gSihl37KjHV/fcz7+u67ke8+8Qb/\n0b2U1gNdRIe07FSVlTC/ejp1tAdWf0bvbs49KcEorerqKZJ1umYwVQT0uBl+zeBQTz8bWzt5/q0D\nPPdWB8+/dYAHBz5NY2jfiI/bSRWX8E36I7EAiESP/R78uvimwPftCVXzpZNXM79qOvOryzixajon\nVk+nfHDo5gRj/qu7p0hm6JpBrhvD0fOM0iLOO7nq7eGU3R1uCz5Sr6OdD5/dSFFBiKICiz8eXW5Y\nF/y+OdF9fP1jv5e4nqlMyC4iWaMwmEqOc5A0M0vYvGQVjXzx8tMTv/np4PclvairJh+RKUlhkOvG\ne6SeyhG+RvYUmXJy9JZWedvia2LXFSrmAhZ7HMu9CeN9n4hMSbqALCKSQ8Z7AVlnBiIikloYmNlH\nzGyTmUXNLDCJzGyumT1mZi/Ht/2LVMoUEZH0S/XM4CXgQ8CTo2wzAPy1uy8ClgJ/bmaLUixXRETS\nKKXeRO6+GeJdGBNvswvYFV8+ZGabgQbg5VTKFhGR9MnoNQMzmwecBTyVyXJFRGR0Sc8MzOxRoDbg\npZXu/sBYCzKzMuDnwF+6+8FRtlsBrIg/PWxmr461jCmoChg55kN+0z4Jpv0ykvbJSFXACeN5Y1q6\nlprZ48Dn3T2wH6iZFQH/CTzi7v+ScoE5wsxaxtMFLJdpnwTTfhlJ+2SkVPbJhDcTWeyCwneAzQoC\nEZHJKdWupVebWStwLvCQmT0SX19vZmvjm50H/C/gfWa2If53WUq1FhGRtEq1N9F9wH0B63cCl8WX\nfw1Mkmm4Jp1V2a7AJKR9Ekz7ZSTtk5HGvU8m9XAUIiKSGRqOQkREFAaZYGaXmtmrZva6md0c8Pqn\nzKxtyDWVG7JRz0wys++a2V4zC5z+zGLuiu+zjWY2yow6uWEM++RCM+sc8j3J+RmDxjKcTb59V8a4\nT47/u+Lu+pvAP6AAeAOYDxQDLwCLhm3zKeDr2a5rhvfLBcDvAS8leP0y4GFi15uWAk9lu86TYJ9c\nCPxntuuZ4X1SB/xefHkG8FrAv5+8+q6McZ8c93dFZwYTbwnwurtvdfc+4MfAlVmuU9a5+5PA/lE2\nuRL4vsf8Fqg0s7rM1C47xrBP8o6773L35+LLh4DB4WyGyqvvyhj3yXFTGEy8BmDo/JGtBP+P+4P4\nKe7PzGxuZqo2qY11v+Wbcx2goC0AAAF3SURBVM3sBTN72MxGmbc094wynE3efleSDPFzXN8VhcHk\n8CAwz90XA+uAe7JcH5mcngNOcPd3Av8G3J/l+mTMWIezySdJ9slxf1cUBhNvBzD0SL8xvu5t7t7u\n7r3xp3cDZ2eobpNZ0v2Wb9z9oLsfji+vBYrMrCrL1Zpw8eFsfg78yN3vDdgk774ryfbJeL4rCoOJ\n9wywwMxONLNi4DpgzdANhrVvXkGsDTDfrQE+Ge8pshTo9Nhw6HnLzGrjw7tgZkuI/fttz26tJtYY\nh7PJq+/KWPbJeL4rKd2BLMm5+4CZ3Qg8Qqxn0XfdfZOZ3Q60uPsa4CYzu4LYRED7ifUuymlm9v+I\n9Xioig9p8kWgCMDdvwWsJdZL5HWgC/jD7NQ0c8awTz4MfNrMBoBu4DqPdx3JYYPD2bxoZhvi6/4G\naIK8/a6MZZ8c93dFdyCLiIiaiURERGEgIiIoDEREBIWBiIigMBARERQGIiKCwkBERFAYiIgI8P8B\nmre+LRZPDbUAAAAASUVORK5CYII=\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          }
-        }
-      ]
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting blueqat\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/f6/73/20f9cff48caee1f69190f2e1ea93c4d7d0a745fc48defb5d3072d8337583/blueqat-0.3.13-py3-none-any.whl (50kB)\n",
+      "\r",
+      "\u001b[K     |██████▌                         | 10kB 13.4MB/s eta 0:00:01\r",
+      "\u001b[K     |█████████████                   | 20kB 3.0MB/s eta 0:00:01\r",
+      "\u001b[K     |███████████████████▍            | 30kB 3.7MB/s eta 0:00:01\r",
+      "\u001b[K     |█████████████████████████▉      | 40kB 2.9MB/s eta 0:00:01\r",
+      "\u001b[K     |████████████████████████████████| 51kB 2.4MB/s \n",
+      "\u001b[?25hCollecting openfermionblueqat\n",
+      "  Downloading https://files.pythonhosted.org/packages/e0/ef/d2a4242ef5f4ff518921dfd608d7841f476e947bc23efc25bd7c3ba0042d/openfermionblueqat-0.2.2-py3-none-any.whl\n",
+      "Collecting openfermion\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/66/72/e058e3d8ececd54212bb98848e8e8227d4887fed6fe8d87f425a034add8b/openfermion-0.10.0.tar.gz (625kB)\n",
+      "\u001b[K     |████████████████████████████████| 634kB 8.8MB/s \n",
+      "\u001b[?25hRequirement already satisfied: scipy>=1.1.0 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.4.1)\n",
+      "Requirement already satisfied: numpy~=1.12 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.17.5)\n",
+      "Requirement already satisfied: h5py>=2.8 in /usr/local/lib/python3.6/dist-packages (from openfermion) (2.8.0)\n",
+      "Requirement already satisfied: future in /usr/local/lib/python3.6/dist-packages (from openfermion) (0.16.0)\n",
+      "Requirement already satisfied: jupyter in /usr/local/lib/python3.6/dist-packages (from openfermion) (1.0.0)\n",
+      "Requirement already satisfied: nbformat in /usr/local/lib/python3.6/dist-packages (from openfermion) (5.0.4)\n",
+      "Requirement already satisfied: networkx in /usr/local/lib/python3.6/dist-packages (from openfermion) (2.4)\n",
+      "Requirement already satisfied: matplotlib in /usr/local/lib/python3.6/dist-packages (from openfermion) (3.1.3)\n",
+      "Collecting pubchempy\n",
+      "  Downloading https://files.pythonhosted.org/packages/aa/fb/8de3aa9804b614dbc8dc5c16ed061d819cc360e0ddecda3dcd01c1552339/PubChemPy-1.0.4.tar.gz\n",
+      "Requirement already satisfied: six in /usr/local/lib/python3.6/dist-packages (from openfermion) (1.12.0)\n",
+      "Requirement already satisfied: qtconsole in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (4.6.0)\n",
+      "Requirement already satisfied: ipywidgets in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (7.5.1)\n",
+      "Requirement already satisfied: jupyter-console in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (5.2.0)\n",
+      "Requirement already satisfied: notebook in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (5.2.2)\n",
+      "Requirement already satisfied: nbconvert in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (5.6.1)\n",
+      "Requirement already satisfied: ipykernel in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (4.6.1)\n",
+      "Requirement already satisfied: jsonschema!=2.5.0,>=2.4 in /usr/local/lib/python3.6/dist-packages (from nbformat->openfermion) (2.6.0)\n",
+      "Requirement already satisfied: traitlets>=4.1 in /usr/local/lib/python3.6/dist-packages (from nbformat->openfermion) (4.3.3)\n",
+      "Requirement already satisfied: ipython-genutils in /usr/local/lib/python3.6/dist-packages (from nbformat->openfermion) (0.2.0)\n",
+      "Requirement already satisfied: jupyter-core in /usr/local/lib/python3.6/dist-packages (from nbformat->openfermion) (4.6.2)\n",
+      "Requirement already satisfied: decorator>=4.3.0 in /usr/local/lib/python3.6/dist-packages (from networkx->openfermion) (4.4.1)\n",
+      "Requirement already satisfied: kiwisolver>=1.0.1 in /usr/local/lib/python3.6/dist-packages (from matplotlib->openfermion) (1.1.0)\n",
+      "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.6/dist-packages (from matplotlib->openfermion) (0.10.0)\n",
+      "Requirement already satisfied: pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 in /usr/local/lib/python3.6/dist-packages (from matplotlib->openfermion) (2.4.6)\n",
+      "Requirement already satisfied: python-dateutil>=2.1 in /usr/local/lib/python3.6/dist-packages (from matplotlib->openfermion) (2.6.1)\n",
+      "Requirement already satisfied: pygments in /usr/local/lib/python3.6/dist-packages (from qtconsole->jupyter->openfermion) (2.1.3)\n",
+      "Requirement already satisfied: jupyter-client>=4.1 in /usr/local/lib/python3.6/dist-packages (from qtconsole->jupyter->openfermion) (5.3.4)\n",
+      "Requirement already satisfied: ipython>=4.0.0; python_version >= \"3.3\" in /usr/local/lib/python3.6/dist-packages (from ipywidgets->jupyter->openfermion) (5.5.0)\n",
+      "Requirement already satisfied: widgetsnbextension~=3.5.0 in /usr/local/lib/python3.6/dist-packages (from ipywidgets->jupyter->openfermion) (3.5.1)\n",
+      "Requirement already satisfied: prompt-toolkit<2.0.0,>=1.0.0 in /usr/local/lib/python3.6/dist-packages (from jupyter-console->jupyter->openfermion) (1.0.18)\n",
+      "Requirement already satisfied: tornado>=4 in /usr/local/lib/python3.6/dist-packages (from notebook->jupyter->openfermion) (4.5.3)\n",
+      "Requirement already satisfied: terminado>=0.3.3; sys_platform != \"win32\" in /usr/local/lib/python3.6/dist-packages (from notebook->jupyter->openfermion) (0.8.3)\n",
+      "Requirement already satisfied: jinja2 in /usr/local/lib/python3.6/dist-packages (from notebook->jupyter->openfermion) (2.11.1)\n",
+      "Requirement already satisfied: mistune<2,>=0.8.1 in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (0.8.4)\n",
+      "Requirement already satisfied: entrypoints>=0.2.2 in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (0.3)\n",
+      "Requirement already satisfied: bleach in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (3.1.0)\n",
+      "Requirement already satisfied: testpath in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (0.4.4)\n",
+      "Requirement already satisfied: defusedxml in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (0.6.0)\n",
+      "Requirement already satisfied: pandocfilters>=1.4.1 in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (1.4.2)\n",
+      "Requirement already satisfied: setuptools in /usr/local/lib/python3.6/dist-packages (from kiwisolver>=1.0.1->matplotlib->openfermion) (45.1.0)\n",
+      "Requirement already satisfied: pyzmq>=13 in /usr/local/lib/python3.6/dist-packages (from jupyter-client>=4.1->qtconsole->jupyter->openfermion) (17.0.0)\n",
+      "Requirement already satisfied: simplegeneric>0.8 in /usr/local/lib/python3.6/dist-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets->jupyter->openfermion) (0.8.1)\n",
+      "Requirement already satisfied: pickleshare in /usr/local/lib/python3.6/dist-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets->jupyter->openfermion) (0.7.5)\n",
+      "Requirement already satisfied: pexpect; sys_platform != \"win32\" in /usr/local/lib/python3.6/dist-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets->jupyter->openfermion) (4.8.0)\n",
+      "Requirement already satisfied: wcwidth in /usr/local/lib/python3.6/dist-packages (from prompt-toolkit<2.0.0,>=1.0.0->jupyter-console->jupyter->openfermion) (0.1.8)\n",
+      "Requirement already satisfied: ptyprocess; os_name != \"nt\" in /usr/local/lib/python3.6/dist-packages (from terminado>=0.3.3; sys_platform != \"win32\"->notebook->jupyter->openfermion) (0.6.0)\n",
+      "Requirement already satisfied: MarkupSafe>=0.23 in /usr/local/lib/python3.6/dist-packages (from jinja2->notebook->jupyter->openfermion) (1.1.1)\n",
+      "Requirement already satisfied: webencodings in /usr/local/lib/python3.6/dist-packages (from bleach->nbconvert->jupyter->openfermion) (0.5.1)\n",
+      "Building wheels for collected packages: openfermion, pubchempy\n",
+      "  Building wheel for openfermion (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+      "  Created wheel for openfermion: filename=openfermion-0.10.0-cp36-none-any.whl size=731375 sha256=b376fd0f66f7ad4e2d5b4244a8ed6bdfe83674c2cb123f62b0f58ab24af5c6b9\n",
+      "  Stored in directory: /root/.cache/pip/wheels/3c/49/cd/098bb337ffcbb70021864403773043df332c065590873f1813\n",
+      "  Building wheel for pubchempy (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+      "  Created wheel for pubchempy: filename=PubChemPy-1.0.4-cp36-none-any.whl size=13825 sha256=170181c246083c6094378e11cb63d2801a0ba573cefb45615659e2c69fd0e1eb\n",
+      "  Stored in directory: /root/.cache/pip/wheels/10/4d/51/6b843681a9a5aef35f0d0fbce243de46f85080036e16118752\n",
+      "Successfully built openfermion pubchempy\n",
+      "Installing collected packages: blueqat, pubchempy, openfermion, openfermionblueqat\n",
+      "Successfully installed blueqat-0.3.13 openfermion-0.10.0 openfermionblueqat-0.2.2 pubchempy-1.0.4\n"
+     ]
     }
-  ]
+   ],
+   "source": [
+    "!pip3 install blueqat openfermionblueqat openfermion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "HHLJDoRXtXta"
+   },
+   "source": [
+    "##2-3-2 コードをざっくり\n",
+    "今回はopenfermionに準備されたコードを使います。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 283
+    },
+    "colab_type": "code",
+    "id": "hDacEDd6tVIK",
+    "outputId": "cdb33658-119e-4c37-caf6-04d06ba417b7"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x7f6b8f08c1f0>]"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYMAAAD5CAYAAADFqlkBAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3deXxc5X3v8c9vRtt4kWRbkq3FxjYYG0McSIRjQkpwMElwICZpQ8jScnNv6puFOKHJq4XSAqFpw6u9WeBmddPc0jZt4gYIJjEl4LAk9BXALDE4BuzYwZZXWbbkRfvM7/4xYyxLZ7TNaEaa832/XnrNzJlz5nk4HM93zvM85zzm7oiISLhF8l0BERHJP4WBiIgoDERERGEgIiIoDEREBIWBiIgARdn4EDN7N3AnEAW+5+539Hv/I8BfpF4eBz7p7r8Z6nOrqqp87ty52aiiiEgoPPvss4fcvXqk22UcBmYWBb4JXA40Ac+Y2Xp3/22f1XYCb3f3I2Z2BbAWeMtQnz137lw2bdqUaRVFRELDzF4bzXbZaCZaCmx39x3u3g38EFjVdwV3/293P5J6+WugIQvliohIlmQjDOqB3X1eN6WWpfO/gAezUK6IiGRJNvoMLGBZ4D0uzGw5yTB4W9oPM1sNrAaYM2dOFqonIiJDycaZQRMwu8/rBmBv/5XMbAnwPWCVu7ek+zB3X+vuje7eWF094j4QEREZhWyEwTPAAjObZ2YlwLXA+r4rmNkc4F7gj9391SyUKSIiWZRxM5G795rZ9cBDJIeWft/dt5jZJ1Lvfwe4BZgBfMvMAHrdvTHTsgNtXgcbb4e2JqhogMtugSXXjElRIiKFwsbzLawbGxt9RENLN6+DB9ZAT8epZcUxuOouBYKIhIKZPTuaH9uFdQXyxttPDwJIvt54e37qIyIyQRRWGLQ1jWy5iIgAhRYGFWmuZUu3XEREgEILg8tuSfYR9FUcSy4XEZG0CisMllwDV91Fa/FMEhhUzFbnsYjIMGTlrqXjypJr+NGRN/PlB19m843vpLysON81EhEZ9wrrzCClflqyqWhva8cQa4qICBRoGNRVKgxEREaiIMOgIRUGe44oDEREhqMgw6BqSikl0Qh7WjvzXRURkQmhIMMgEjFqK8vYo2YiEZFhKcgwAKiriKnPQERkmAo2DOqnxdRnICIyTAUbBnWVMQ4c66Qnnsh3VURExr2CDYOGyhjusL9NncgiIkMp2DA4ea2BOpFFRIZWsGFw8ipk9RuIiAytYMOgtqIM0JmBiMhwFGwYlBVHqZpSquGlIiLDULBhAKnhpQoDEZEhFXYY6CpkEZFhKfAwSF6F7O75roqIyLiWlTAws3eb2Stmtt3Mbgx438zsrtT7m83sTdkodyh1lTE6exIcPtGdi+JERCasjMPAzKLAN4ErgMXAh8xscb/VrgAWpP5WA9/OtNzhqNe1BiIiw5KNM4OlwHZ33+Hu3cAPgVX91lkF/Isn/RqoNLPaLJQ9KE1yIyIyPNkIg3pgd5/XTallI10HADNbbWabzGxTc3NzRhVrSF141qQLz0REBpWNMLCAZf17bIezTnKh+1p3b3T3xurq6owqVhErZlJJlL2a5EZEZFDZCIMmYHaf1w3A3lGsk3VmRn1ljD2t7WNdlIjIhJaNMHgGWGBm88ysBLgWWN9vnfXAn6RGFS0D2tx9XxbKHlJdZUxnBiIiQyjK9APcvdfMrgceAqLA9919i5l9IvX+d4ANwEpgO9AOfCzTcoerflqMF/e05ao4EZEJKeMwAHD3DSS/8Psu+06f5w58OhtljVR9ZYzDJ7rp6I4TK4nmowoiIuNeQV+BDLrWQERkOAo+DHStgYjI0Ao+DF6f5EZhICKSVsGHwcyppUQjphnPREQGUfBhUBSNMKu8TM1EIiKDKPgwAKirLKNJYSAiklYowuDkvAYiIhIsFGFQVxljf1sn8YQmuRERCRKKMKifFqM34Rw8pttSiIgECUcYnLzwTCOKREQChSsM1G8gIhIoFGFQpzAQERlUKMJgcmkRlZOKNaJIRCSNUIQBJJuK1GcgIhIsNGGgSW5ERNILTRgkp7/sIDm1goiI9BWqMDje1cvRzt58V0VEZNwJTxhM07UGIiLphCYMNLxURCS90IRBvWY8ExFJKzRhMGNyCSVFEZ0ZiIgEyCgMzGy6mT1sZttSj9MC1pltZo+a2VYz22Jmn82kzNGKROz1EUUiInK6TM8MbgQ2uvsCYGPqdX+9wOfd/RxgGfBpM1ucYbmjUldZpg5kEZEAmYbBKuDu1PO7gav7r+Du+9z9udTzY8BWoD7DckdFk9yIiATLNAxmuvs+SH7pAzWDrWxmc4ELgKcyLHdU6ipjHDzWRVdvPB/Fi4iMW0VDrWBmjwCzAt66eSQFmdkU4B7gc+5+dJD1VgOrAebMmTOSIoZ0ckTR/rZOzpgxOaufLSIykQ0ZBu6+It17ZnbAzGrdfZ+Z1QIH06xXTDIIfuDu9w5R3lpgLUBjY2NW7x3Rd5IbhYGIyCmZNhOtB65LPb8OuL//CmZmwD8BW939qxmWl5HXr0JWv4GIyGkyDYM7gMvNbBtweeo1ZlZnZhtS61wM/DHwDjN7IfW3MsNyR2VWRRmgMBAR6W/IZqLBuHsLcFnA8r3AytTzXwGWSTnZUloUpWZqqUYUiYj0E5orkE+q04VnIiIDhC4M6qdpkhsRkf5CFwYNqTODREKT3IiInBS6MKirjNHdm6DlRHe+qyIiMm6ELgzqNa+BiMgAoQuDukrNeCYi0l/owuDkhWcaXioickrowqC8rIgppUVqJhIR6SN0YWCmSW5ERPoLXRiAJrkREekvlGFQPy3G3jaFgYjISaEMg7rKGK3tPZzo6s13VURExoVQhsHJaw00okhEJCnUYdCkMBARAcIaBrrWQETkNKEMg5qpZRRFTCOKRERSQhkG0Ygxq6JMZwYiIimhDAPQJDciIn2FNgwaKjXJjYjISaENg7rKGPuPdtIbT+S7KiIieRfaMKifFiOecA4c68p3VURE8i60YaB5DURETskoDMxsupk9bGbbUo/TBlk3ambPm9lPMykzW07NeNae55qIiORfpmcGNwIb3X0BsDH1Op3PAlszLC9rTt2SQp3IIiKZhsEq4O7U87uBq4NWMrMG4D3A9zIsL2tiJVGmTy6hSc1EIiIZh8FMd98HkHqsSbPe14E/B4YcumNmq81sk5ltam5uzrB6g6uvjOnCMxERoGioFczsEWBWwFs3D6cAM7sSOOjuz5rZpUOt7+5rgbUAjY2NPpwyRquusozfNZ8YyyJERCaEIcPA3Veke8/MDphZrbvvM7Na4GDAahcD7zWzlUAZUG5m/+buHx11rbOkvnISv9x2CHfHzPJdHRGRvMm0mWg9cF3q+XXA/f1XcPeb3L3B3ecC1wK/GA9BAMkzg/buOK3tPfmuiohIXmUaBncAl5vZNuDy1GvMrM7MNmRaubHWMO3k8FL1G4hIuA3ZTDQYd28BLgtYvhdYGbD8MeCxTMrMptcvPGvt4Lz6ijzXRkQkf0J7BTJo+ksRkZNCHQbTJ5dQVhzRLSlEJPRCHQZmRl1ljL1tCgMRCbdQhwEkm4p0ZiAiYacwqIyxR/cnEpGQC30Y1FXGOHS8i86eeL6rIiKSN6EPg5Mjiva16exARMIr9GGgSW5ERBQGfa5C1iQ3IhJeoQ+DmeVlmKFOZBEJtdCHQUlRhJlTy9RMJCKhFvowgOTdS3VLChEJM4UBUD9tku5cKiKhpjAgeWawr62DRGJMJ1YTERm3FAZAQ2WMnrjTfLwr31UREckLhQFQr0luRCTkFAbowjMREYUBmuRGRERhAEwtK2ZqWZGaiUQktBQGKfWVMZ0ZiEhoKQxS6itjNKnPQERCKqMwMLPpZvawmW1LPU5Ls16lmf3YzF42s61mdlEm5Y6F+mk6MxCR8Mr0zOBGYKO7LwA2pl4HuRP4L3dfBLwR2JphuVl3SeejbEh8Cr+tEr52Hmxel+8qiYjkTKZhsAq4O/X8buDq/iuYWTlwCfBPAO7e7e6tGZabXZvXcemrX6IhcgjDoW03PLBGgSAioZFpGMx0930AqceagHXmA83A/zOz583se2Y2OcNys2vj7RTF+93CuqcDNt6en/qIiOTYkGFgZo+Y2UsBf6uGWUYR8Cbg2+5+AXCC9M1JmNlqM9tkZpuam5uHWUSG2ppGtlxEpMAUDbWCu69I956ZHTCzWnffZ2a1wMGA1ZqAJnd/KvX6xwwSBu6+FlgL0NjYmJs7x1U0JJuGgpaLiIRAps1E64HrUs+vA+7vv4K77wd2m9nC1KLLgN9mWG52XXYLFMdOX1YcSy4XEQmBTMPgDuByM9sGXJ56jZnVmdmGPut9BviBmW0Gzgf+LsNys2vJNXDVXXRNrifhRnusFq66K7lcRCQEzH383sO/sbHRN23alLPy4gmn8UsPc+nCGr72wfNzVq6ISLaY2bPu3jjS7XQFch/RiPH2s6t5/NVm4proRkRCRGHQz/JFNRw+0c3mpvF1KYSIyFhSGPRzyYJqIgaPvhw0MEpEpDApDPqZNrmEC+ZM49FXcnSNg4jIOKAwCLB8YTUv7mnj4LHOoVcWESkACoMAyxcl76rxuM4ORCQkFAYBFteWUzO1lMcUBiISEgqDAGbG8oU1PPFqMz3xRL6rIyIy5hQGaSxfVM2xrl6efe1IvqsiIjLmFAZpXHxWFcVR49FXNMRURAqfwiCNqWXFXDh3Oo+9rH4DESl8CoNBLF9YwysHjrFHcyOLSIFTGAxi+aJqQFcji0jhUxgM4szqKTRMi/GY+g1EpMApDAZxcojpk9tb6OyJ57s6IiJjRmEwhHcsqqGjJ87TOw/nuyoiImNGYTCEZfNnUFoU0RBTESloCoMhxEqiXHTmDHUii0hBUxgMw/KFNfy+pZ2dh07kuyoiImNCYTAMyxcm72KqswMRKVQKg2GYM2MSZ1ZPVr+BiBQshcEwLV9Yw1M7DtPe3ZvvqoiIZF1GYWBm083sYTPblnqclma9G8xsi5m9ZGb/YWZlmZSbD8sX1dAdT/Dk9pZ8V0VEJOsyPTO4Edjo7guAjanXpzGzemAN0Oju5wFR4NoMy825C+dOZ3JJVE1FIlKQMg2DVcDdqed3A1enWa8IiJlZETAJ2JthuTlXUhThbQuqeOzlg7h7vqsjIpJVmYbBTHffB5B6rOm/grvvAf4PsAvYB7S5+88zLDcvli+sYW9bJ68eOJ7vqoiIZNWQYWBmj6Ta+vv/rRpOAal+hFXAPKAOmGxmHx1k/dVmtsnMNjU3j6+5BC49OcRUTUUiUmCGDAN3X+Hu5wX83Q8cMLNagNRj0LfkCmCnuze7ew9wL/DWQcpb6+6N7t5YXV09uv+qMTKrooxzasv5ha43EJECk2kz0XrgutTz64D7A9bZBSwzs0lmZsBlwNYMy82b5Qurefa1I7R19OS7KiIiWZNpGNwBXG5m24DLU68xszoz2wDg7k8BPwaeA15Mlbk2w3Lz5h2LaognnF9tO5TvqoiIZE1RJhu7ewvJX/r9l+8FVvZ5fStwayZljRfnz66kIlbMo68c5D1LavNdHRGRrNAVyCNUFI1wydnVPPZKM4mEhpiKSGFQGIzC8oXVHDrexUt72/JdFRGRrFAYjMLbz67GDB59eXwNfRURGS2FwSjMmFLKGxsqdb2BiBQMhcEoLV9Yw2+aWmk53pXvqoiIZExhMErLF1XjDk9sU1ORiEx8CoNROq+ugqoppfxC/QYiUgAUBqMUiRiXLqzmiVeb6Y0n8l0dEZGMKAwysHxhDW0dPbywuzXfVRERyYjCIAPLux/jydI1vPmf58PXzoPN6/JdJRGRUcnodhShtnkdkx66gUnWkXzdthseWJN8vuSa/NVLRGQUdGYwWhtvh56O05f1dCSXi4hMMAqD0WprGtlyEZFxTGEwWhUNI1suIhPP5nXJ/sDbKkfWL5jr7bJAfQajddktyT6CPk1FHZTif3Azk/JYLZGCt3ldsjm2rSn54+uyW4bXTzfS7TavO/3f+HD7BQO28wfW0NOboHPxHxKPOz2JBL1xT/4lEvQmnNjL91D/xI1E4vnphzT38Xsb5sbGRt+0aVO+q5Fen4Ore0odf956NWUXXMsdf7gk3zUTGf9G86Xe/4sWoDgGV92Vdlt3p/v5H1Gy4XNY76nt4tEYryz9Ervqr6SrN05nT5zOngSdPXG6ehNc99SVVHTvH/B5h6I1fK723+iOJ+juTf71xBN0xxP09Ca4p2s1tQyc/KopUcXbuu9K+5/2q5I1NEQCJs2qmA03vDTITjmdmT3r7o3D3iBFZwaZWHLN6wdgCTDzwa189/EdvPf8Ot56ZlV+6yaSK9n4Ug/4FdzZE+doRw9HO3to6+jlaGcPb3nwFiYFDNxoWf9X/NmmubR393KiK5587I7T3tVLe0+cXxbfTEPk9O2i8Q7Kn/wyn+gOnqTq+tL9YAOXT483097dS0lRhKllRZQWRSiORihJPc7a0hL4efWRFv7qPedQFDGi0QjFEaMoGqEoYhRFjfp7g7fLVT+kwiCLblhxNv/10n5uuvdFHvrcJZQVR/NdJZGxNYwv9d54giPtPRw+0U3LiS4On+jm0g23MCXgS33/fX/Jleunc7Szh+7egVf27yjdF/gFPa33IK0dPUwuiVJXWcLk0iiTSoqYXBJlUmkR9U+m/4L+2Zq3UVYcTf4VRShNPUbump387+knUtHAvZ+6OP0+aWoI3M4qGvj4H8xPv93G4O1y1Q+pMMiisuIoX37/G/jwPz7F1x/Zxo1XLMp3lSSMctCmHk84Lce7qPz5bZQEfKk3/+RmPvhwDYdPdNPW0UP/1uh0X+oz/RCXL55JRayY8lgR5WXFlMeKKS8rojxWTHxdPZHjewZsF6lo4P5PD/IF/VL6L+hz6yqCtwnoF6Q4llw+mFxvlyUKgyx765lVfLBxNv/4yx1cuaSW8+rTHGgiYyGLnZ7x+9fw3O+P8GzFCva3dXLgaCf7j3ayv62Tg8e6iCecHaV7Ar/UZySaOWdWOdMnlzB9cgkzppScej65FP9BAxwb2PxhFQ18+f1vSF/Pd96Wuy/ak/trpMGa6+2yRB3IY6CtvYcVX3ucmqml3P/piymKagSv5MjXzkvT1HCqEzKRcA4c6+S1lnZ2HW5n9+F2Pvb0VUzvPTBgs5OdnlNKi5hVUcas8jJmlpcxq6KUWeVl/NEvryDWvnfQ8gKNoiP4tG1zMZpoghptB7LCYIw8+OI+PvmD57jpikX877efme/qSFjcVgkM/DftGB874+fsOtxO0+EOuvvcaTdisL30I0TSbHfipkNMKU3TiJCPL3UZVF5GE5nZB4DbgHOApe4e+M1tZu8G7gSiwPfc/Y5Myp0IrnhDLe86dyZfffhV3nXuLOZWTc53lWQiGuIL81hnD79rPsG2A8fY3nycP41WUxUfOB3rPmZw6HgXi2ZN5fLFM5kzfdLrf3WVMSJ3pW9TTxsEkFnTRp/ReJJ/GZ0ZmNk5QAL4LvCFoDAwsyjwKnA50AQ8A3zI3X871OdP5DMDgANHO1nxlcc5r76Cf//Tt2AW0Lgqkk7Ar+7eSBn3z/kLfhK/mO0Hj7OvrfP190qiEf5n+TPc0PkNSv3UdKxeFMPeO8Qv9Ux+4cu4kpczA3ffmip8sNWWAtvdfUdq3R8Cq4Ahw2Cim1lexk0rz+Ev73uRdZt288EL5+S7SpIvw2wSSSScnS0n+O3eo1zys7+mot9InaJEJ8t2fpN/rlrKRfNncGbNFBbUTOGsminMmT6JougVsHnRaWXZBOi8lPzLxWiieqDv+WcT8JZ0K5vZamA1wJw5E//L89oLZ3P/C3v4259tZfnCGmrKy/JdJcm1NCN8ehIJXqm+gi1729iy9yhb9h5l676jtHfHAdiR5qKnOmvhgc+8LX15o21+UbNNqA0ZBmb2CDAr4K2b3f3+YZQRdNqQtm3K3dcCayHZTDSMzx/XIhHjy+9/A+++85fc9sAWvvWRN+e7SpJraW53fvC+m7myayoAk0uiLK4r55rG2SyuK+fcunLsRw2BV5+aboYoY2DIMHD3FRmW0QTM7vO6AQgYi1a45ldP4bOXLeAfHnqFh7bs513nBmWrTAjDaO5xd37f0s7zu47w/K5WvtjWFHh74Dpr4RsfvoBz6yo4Y/okIpF+v5suuzWvFyFJuOSimegZYIGZzQP2ANcCH85BuePK6kvm89PN+/jrn7zEsvkzqIgV57tKMlJpmnvau+NsKl/B87taeX73EV7Y3Uprew+Q/MW/pria6oARPlbRwJVL6tKXp3Z8yaFMRxO9D/i/QDXQCrzg7u8yszqSQ0hXptZbCXyd5NDS77v73w7n8yf6aKL+Nje1cvU3n+TapXP4u/cNcpWljE9pLug6eWGWGSyomcIFs6dxwZxKLpgzjbNqphB96T81UkdyJl+jie4D7gtYvhdY2ef1BmBDJmUVgiUNlXz8D+az9okdvPeNdSybPyPfVZIhdPcmeHFPK0/vPMIn2poCO8DqIy384ONvYUlDBVPLAs749AtfJgDdmyjHblhxNr3P/4i5//pZ3A8lOwP1xZB7adr+j3f18uxrR9j0+8M8vfMwL+xupSt198z3xaqY5c0DPsoqGrj4rCFuWa6ROjLOKQxyLPbyPdyc+A5Rz89sRkJg23/3fddz50Mv8+3DbybhEI0Y59aV89FlZ3Dh3Gk0zp1O1Y6/U4euFCyFQa5tvJ1ofOAwQzberjDIgYNHO5ny4K0DJkgp8S7+R+e/El3+QS6cN50L5kwbeBsGNfdIAVMY5FqaWYs8TXu0DGGIoZ772zp5amcLv97RwlM7DrPj0Al2lO4NvPqlOt7Mn71z4eDlqblHCpTCINcqgm8Itsdn8K8PbuWGFWdrhrThCmjuSaxfw7O/P8yPu9/KUztb+H1LOwBTy4pYOnc6H1o6h96n6ykJmCAlVzNKiYxHCoNcC5hkw4ti/Kr2k3z38R38YutBvnLNG1nSUJnHSk4MvvF2rF9zT6S3g9pN/8CDkW+xdN4MPrrsDJbNn8E5teVET17UVXmb2v5F+lEY5FpAu7NddgvXLrmGWa8c5MZ7XuR93/pvPnXpmXzmHQsoKdLEOCe5O79rPs5TO5Mjfb42yFDP529556kv//7U9i8ygCa3GWfaOnr44gNbuPe5PZxTW85XPvBGFteV57taYy+g7T9+3gd4ef9Rnk59+T+98zAtJ7oBqJ5ayn/5p5gRMDvXkLNsiRQwzXRWYB7+7QFuuvdF2jq6WfOOBXzi0jMpLtTpMwPupd9lpdziq/lR50UANEyLsXTedN4ybzpL581g7oxJ2Iu6slekP4VBATpyoptb1m/hgd/s5Q31Faw9fwe1m/6+IJo23J3XWtp5YXcrl25YTmXPwF/4R4pn8vjKR7lw3nTqK2PBH6SpE0VOozAoYD/bvI8n7/sWf5X4DpOs+9Qb4/VXcMAX9JEzr+aFplZe2NXKC7tb+U3TqZu57Sj9CBELOg4NbmvNbd1FJri83JtIcuM9S2p598P3Ej3WffobPR30/Pw2oud9YODtj/Nl8zp8/Rqs99Rwz857r+fW7udZn3gbEYOzZ07lXYtncf6cSs6fXYn9sD74+gsN9RTJGYXBBBE9FjAuHoge28sFf/Mw58+ufP1OmefPrjz9FtmjbUoZZLuu3ji7WtqTF3E1n2DnoePsPHSCO/ffRB2nD/cso4u/nXofH7rmC7yhoWLglb26b79I3ikMJoo0F6t1TJrFygWzeO61Vu7cuI2TrX5n1UzhgtmVvK/ov1m25YtEege/F1Ii4fQkEvTEnZ7eBJGX/pOpD3/+tO2677ue7z/+O/69YxlNR9pJ9GnZqZpSyvzqydTSElj9qV37uejMNHdp1VBPkbxTn8FEETDipn+fwbHOHjY3tfH8riM8t6uV53cd4YHeT9IQOTTg4/ZSxbv4Fj3xZADEE6cfB78qWRO43YFINX9z1jrmV01mfvUU5lVNZl71ZMpP3ro5zT3/NdxTJDfUZ1DohvHreWpZMRefVfX67ZTdHb4Y/Eu9lhb+6M0NFEcjFEct9Xjqef3DwdvNTBziGx9+U/p6BlxhrSYfkfFPYTCRjPAmaWaWtnnJKhq49apz02/8dPB2Q3bqqslHZEJSGBS60f5Sz+QXvu7sKTLhFOglrfK6Jdck+xUqZgOWfBzOtQmj3U5EJiR1IIuIFJDRdiDrzEBERDILAzP7gJltMbOEmQUmkZnNNrNHzWxrat3PZlKmiIhkX6ZnBi8B7weeGGSdXuDz7n4OsAz4tJktzrBcERHJooxGE7n7VkgNYUy/zj5gX+r5MTPbCtQDv82kbBERyZ6c9hmY2VzgAuCpXJYrIiKDG/LMwMweAWYFvHWzu98/3ILMbApwD/A5dz86yHqrgdWpl8fN7JXhljEBVQED7/kQbtonwbRfBtI+GagKOGM0G2ZlaKmZPQZ8wd0Dx4GaWTHwU+Ahd/9qxgUWCDPbNJohYIVM+ySY9stA2icDZbJPxryZyJIdCv8EbFUQiIiMT5kOLX2fmTUBFwE/M7OHUsvrzGxDarWLgT8G3mFmL6T+VmZUaxERyapMRxPdB9wXsHwvsDL1/FfAOJmGa9xZm+8KjEPaJ8G0XwbSPhlo1PtkXN+OQkREckO3oxAREYVBLpjZu83sFTPbbmY3Brx/qZm19elTKfiZYMzs+2Z20MwCpz+zpLtS+2yzmQ0yo05hGMY+CeNxMuTtbMJ2rAxzn4z8WHF3/Y3hHxAFfgfMB0qA3wCL+61zKfDTfNc1x/vlEuBNwEtp3l8JPEiyv2kZ8FS+6zwO9kkYj5Na4E2p51OBVwP+/YTqWBnmPhnxsaIzg7G3FNju7jvcvRv4IbAqz3XKO3d/Ajg8yCqrgH/xpF8DlWZWm5va5ccw9knouPs+d38u9fwYcPJ2Nn2F6lgZ5j4ZMYXB2KsH+s4f2UTw/7iLzOw3ZvagmQ0yH2VoDHe/hU1oj5NBbmcT2mNliFv8jOhY0bSXYy9oWG3/IVzPAWe4+/HUNRg/ARaMec3Gt+Hst7AJ7XEyxO1sQnmsDLFPRnys6Mxg7PSMqEEAAAEPSURBVDUBs/u8bgD29l3B3Y+6+/HU8w1AsZlV5a6K49KQ+y1swnqcpG5ncw/wA3e/N2CV0B0rQ+2T0RwrCoOx9wywwMzmmVkJcC2wvu8KZjYrddsOzGwpyf8vLTmv6fiyHviT1EiRZUCbJ2+HHlphPE6GeTubUB0rw9knozlW1Ew0xty918yuBx4iObLo++6+xcw+kXr/O8AfAZ80s16gA7jWU0MCCpWZ/QfJEQ9VqVua3AoUw+v7ZAPJUSLbgXbgY/mpae4MY5+E7jjh1O1sXjSzF1LL/hKYA6E9VoazT0Z8rOgKZBERUTORiIgoDEREBIWBiIigMBARERQGIiKCwkBERFAYiIgICgMREQH+PzBp48w6QTPCAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from blueqat import *\n",
+    "from openfermion import *\n",
+    "from openfermionblueqat import*\n",
+    "import numpy as np\n",
+    "\n",
+    "def get_molecule(bond_len):\n",
+    "  geometry = [('H',(0.,0.,0.)),('H',(0.,0.,bond_len))]\n",
+    "\n",
+    "  description = format(bond_len)\n",
+    "  molecule = MolecularData(geometry, \"sto-3g\",1,description=description)\n",
+    "\n",
+    "  molecule.load()\n",
+    "  return molecule\n",
+    "\n",
+    "x = [];e=[];fullci=[]\n",
+    "for bond_len in np.arange(0.2,2.5,0.1):\n",
+    "  m = get_molecule(\"{:.2}\".format(bond_len))\n",
+    "  h = bravyi_kitaev(get_fermion_operator(m.get_molecular_hamiltonian()))\n",
+    "  runner = vqe.Vqe(UCCAnsatz(h,6,Circuit().x[0]))\n",
+    "  result = runner.run()\n",
+    "  x.append(bond_len)\n",
+    "  e.append(runner.ansatz.get_energy_sparse(result.circuit))\n",
+    "  fullci.append(m.fci_energy)\n",
+    "\n",
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "plt.plot(x,fullci)\n",
+    "plt.plot(x,e,\"o\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "XC1xaDwbtcxb"
+   },
+   "source": [
+    "今回は水素分子の原子の結合間の距離に応じて、各状態の安定エネルギーをVQEを用いて求めています。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "3vw6h4eytfK2"
+   },
+   "source": [
+    "##2-3-3 中身確認\n",
+    "MoluculearDataというのでOpenFermionに最初から入っているデータを使えるようです。H2でSto-3g系を読み込んでみます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "U2xwZyAItaMu"
+   },
+   "outputs": [],
+   "source": [
+    "def get_molecule(bond_len):\n",
+    "  geometry = [('H',(0.,0.,0.)),('H',(0.,0.,bond_len))]\n",
+    "\n",
+    "  description = format(bond_len)\n",
+    "  molecule = MolecularData(geometry, \"sto-3g\",1,description=description)\n",
+    "\n",
+    "  molecule.load()\n",
+    "  return molecule"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "jy8xNG4Etk2S"
+   },
+   "source": [
+    "原子間距離が0.4のものを読み込んで、ハミルトニアンと呼ばれる基本の式が取得できます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 646
+    },
+    "colab_type": "code",
+    "id": "TO1lSYvbtikE",
+    "outputId": "51191d25-cec4-4d64-a0c5-99ddeebe83d8"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "() 1.322943021475\n",
+       "((0, 1), (0, 0)) -1.4820918858979102\n",
+       "((1, 1), (1, 0)) -1.4820918858979102\n",
+       "((2, 1), (2, 0)) -0.1187350527865787\n",
+       "((3, 1), (3, 0)) -0.1187350527865787\n",
+       "((0, 1), (0, 1), (0, 0), (0, 0)) 0.36843967630348756\n",
+       "((0, 1), (0, 1), (2, 0), (2, 0)) 0.08225771204699692\n",
+       "((0, 1), (1, 1), (1, 0), (0, 0)) 0.36843967630348756\n",
+       "((0, 1), (1, 1), (3, 0), (2, 0)) 0.08225771204699692\n",
+       "((0, 1), (2, 1), (0, 0), (2, 0)) 0.082257712046997\n",
+       "((0, 1), (2, 1), (2, 0), (0, 0)) 0.3626667179796745\n",
+       "((0, 1), (3, 1), (1, 0), (2, 0)) 0.082257712046997\n",
+       "((0, 1), (3, 1), (3, 0), (0, 0)) 0.3626667179796745\n",
+       "((1, 1), (0, 1), (0, 0), (1, 0)) 0.36843967630348756\n",
+       "((1, 1), (0, 1), (2, 0), (3, 0)) 0.08225771204699692\n",
+       "((1, 1), (1, 1), (1, 0), (1, 0)) 0.36843967630348756\n",
+       "((1, 1), (1, 1), (3, 0), (3, 0)) 0.08225771204699692\n",
+       "((1, 1), (2, 1), (0, 0), (3, 0)) 0.082257712046997\n",
+       "((1, 1), (2, 1), (2, 0), (1, 0)) 0.3626667179796745\n",
+       "((1, 1), (3, 1), (1, 0), (3, 0)) 0.082257712046997\n",
+       "((1, 1), (3, 1), (3, 0), (1, 0)) 0.3626667179796745\n",
+       "((2, 1), (0, 1), (0, 0), (2, 0)) 0.36266671797967454\n",
+       "((2, 1), (0, 1), (2, 0), (0, 0)) 0.08225771204699726\n",
+       "((2, 1), (1, 1), (1, 0), (2, 0)) 0.36266671797967454\n",
+       "((2, 1), (1, 1), (3, 0), (0, 0)) 0.08225771204699726\n",
+       "((2, 1), (2, 1), (0, 0), (0, 0)) 0.08225771204699728\n",
+       "((2, 1), (2, 1), (2, 0), (2, 0)) 0.38272169831413727\n",
+       "((2, 1), (3, 1), (1, 0), (0, 0)) 0.08225771204699728\n",
+       "((2, 1), (3, 1), (3, 0), (2, 0)) 0.38272169831413727\n",
+       "((3, 1), (0, 1), (0, 0), (3, 0)) 0.36266671797967454\n",
+       "((3, 1), (0, 1), (2, 0), (1, 0)) 0.08225771204699726\n",
+       "((3, 1), (1, 1), (1, 0), (3, 0)) 0.36266671797967454\n",
+       "((3, 1), (1, 1), (3, 0), (1, 0)) 0.08225771204699726\n",
+       "((3, 1), (2, 1), (0, 0), (1, 0)) 0.08225771204699728\n",
+       "((3, 1), (2, 1), (2, 0), (3, 0)) 0.38272169831413727\n",
+       "((3, 1), (3, 1), (1, 0), (1, 0)) 0.08225771204699728\n",
+       "((3, 1), (3, 1), (3, 0), (3, 0)) 0.38272169831413727"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "m = get_molecule(0.4)\n",
+    "m.get_molecular_hamiltonian()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "MCcUSNvltukv"
+   },
+   "source": [
+    "こちらはパウリ行列の表現ではないので、今回VQEで計算できるように変換をします。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "sP1KphQktw8Z"
+   },
+   "source": [
+    "##2-3-4 量子コンピュータ向け変換\n",
+    "Bravi-Kitaev(ブラビキタエフ)変換やJordan–Wigner(ジョルダンウィグナー)変換がありますが、今回は前者のBK変換をして確認してみると、"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 272
+    },
+    "colab_type": "code",
+    "id": "3B3loOfutn2j",
+    "outputId": "99f7f869-64b7-4297-ac30-52d52b4147ff"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(0.7407724940116754+0j) [] +\n",
+      "(0.041128856023498556+0j) [X0 Z1 X2] +\n",
+      "(0.041128856023498556+0j) [X0 Z1 X2 Z3] +\n",
+      "(0.041128856023498556+0j) [Y0 Z1 Y2] +\n",
+      "(0.041128856023498556+0j) [Y0 Z1 Y2 Z3] +\n",
+      "(0.23528824284103544+0j) [Z0] +\n",
+      "(0.23528824284103542+0j) [Z0 Z1] +\n",
+      "(0.18133335898983727+0j) [Z0 Z1 Z2] +\n",
+      "(0.18133335898983727+0j) [Z0 Z1 Z2 Z3] +\n",
+      "(0.14020450296633868+0j) [Z0 Z2] +\n",
+      "(0.14020450296633868+0j) [Z0 Z2 Z3] +\n",
+      "(0.18421983815174378+0j) [Z1] +\n",
+      "(-0.45353118471995524+0j) [Z1 Z2 Z3] +\n",
+      "(0.19136084915706864+0j) [Z1 Z3] +\n",
+      "(-0.45353118471995524+0j) [Z2]\n"
+     ]
+    }
+   ],
+   "source": [
+    "h = bravyi_kitaev(get_fermion_operator(m.get_molecular_hamiltonian()))\n",
+    "print(h)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "xWER997LuB9V"
+   },
+   "source": [
+    "このようにきちんと変換されました。ちょっと複雑な形をしていますが、これこそがこれまで学んできたパウリ行列の和で書かれたハミルトニアンです。これをVQEにかけますが、今回はUCC理論と呼ばれる上記のハミルトニアンに対応するansatzがあるため効率的に計算ができます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 714
+    },
+    "colab_type": "code",
+    "id": "97RcOB7Rt4_7",
+    "outputId": "730c7fd9-0eed-4349-edd0-24aae9f26ba5"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "params: [0.85735393 0.26435293] val: -0.6509224068364255\n",
+      "params: [0.85735393 0.26435293] val: -0.6509224068364255\n",
+      "params: [1.85735393 0.26435293] val: 0.580869355567871\n",
+      "params: [-0.76068007  0.26435293] val: -0.20314413359369127\n",
+      "params: [0.85735393 0.26435293] val: -0.6509224068364255\n",
+      "params: [0.23931996 0.26435293] val: -0.903069815471201\n",
+      "params: [0.23931996 0.26435293] val: -0.903069815471201\n",
+      "params: [0.23931996 1.26435293] val: 0.14842057356438088\n",
+      "params: [ 0.23931996 -1.35368107] val: -0.004567951712909135\n",
+      "params: [0.23931996 0.26435293] val: -0.903069815471201\n",
+      "params: [ 0.23931996 -0.35368104] val: -0.650711608878654\n",
+      "params: [0.23931996 0.64631893] val: -0.3883091255946547\n",
+      "params: [0.23931996 0.07160234] val: -0.8618597217451346\n",
+      "params: [0.23931996 0.40169069] val: -0.8641588087465389\n",
+      "params: [0.23931996 0.23895891] val: -0.8966507378929758\n",
+      "params: [0.23931996 0.29002096] val: -0.9070474408999273\n",
+      "params: [-0.37871402  0.31568899] val: -0.553377933999168\n",
+      "params: [0.23931996 0.29002096] val: -0.9070474408999273\n",
+      "params: [1.23931996 0.29002096] val: -0.3105572939086208\n",
+      "params: [-1.37871404  0.29002096] val: 0.7032874681139033\n",
+      "params: [0.23931996 0.29002096] val: -0.9070474408999273\n",
+      "params: [-0.37871402  0.29002096] val: -0.580983777550085\n",
+      "params: [0.62128596 0.29002096] val: -0.8355785808178493\n",
+      "params: [0.29940151 0.29002096] val: -0.9099903184370948\n",
+      "params: [0.29940151 0.29002096] val: -0.9099903184370948\n",
+      "params: [0.29940151 1.29002096] val: 0.28346973128496944\n",
+      "params: [ 0.29940151 -1.32801304] val: -0.025995041308686573\n",
+      "params: [0.29940151 0.29002096] val: -0.9099903184370948\n",
+      "params: [ 0.29940151 -0.32801302] val: -0.6160598427869707\n",
+      "params: [0.29940151 0.67198696] val: -0.2724594436070553\n",
+      "params: [0.29940151 0.0918812 ] val: -0.8409210642541183\n",
+      "params: [0.29940151 0.43591898] val: -0.8258151315561796\n",
+      "params: [0.29940151 0.25573944] val: -0.8991548356483374\n",
+      "params: [0.29940151 0.34574904] val: -0.9085870787413266\n",
+      "params: [0.29940151 0.31456423] val: -0.9129850551176981\n"
+     ]
+    }
+   ],
+   "source": [
+    "runner = vqe.Vqe(UCCAnsatz(h,2,Circuit().x[0]))\n",
+    "result = runner.run(verbose = True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "pogBuf8HuG9y"
+   },
+   "source": [
+    "最適化のプロセスが出てきました。パラメータが最適化されながら最小基底状態が探索されています。今回はansatzは量子化学の理論に基づいて電子の配置をするUCCansatzと呼ばれるものが利用されました。通常ansatzの構成は難しいので、理論的な探究が求まれます。最小エネルギーは、"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "colab_type": "code",
+    "id": "7aogyg6YuD6S",
+    "outputId": "48520c01-5ad1-4d42-fc6c-ccf395d1df9b"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "-0.9129850551176981"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "runner.ansatz.get_energy_sparse(result.circuit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "gFgZVsk6uMXf"
+   },
+   "source": [
+    "原子間距離0.4の場合の最小値の期待値が求まりました。これを全体でやったのが最初のコードです。再掲します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 283
+    },
+    "colab_type": "code",
+    "id": "uP2XQ8j3uJnr",
+    "outputId": "83f553f0-957b-4660-b275-4e56a1ef0ab2"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x7f6b8f022a60>]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYMAAAD5CAYAAADFqlkBAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3df3xU9Z3v8ddnJr+GH8kEkpBfIKAIIlK1EbG6VgSrUi3a26qtbb193F2ubS3WbR93tXTRutvWvXtbq3drLWu91+3trmWrVqxYi9Qf1T6KBkEUEaGgEMKPEEj4kd+Z7/1jBgjJTGYyM8kkc97PxyOPmTlzZr5fjuN5n/M93/P9mnMOERHxNl+mKyAiIpmnMBAREYWBiIgoDEREBIWBiIigMBARESAnHV9iZlcBDwB+4BHn3H293r8Z+LvIy6PAV5xzb8X73pKSEjd58uR0VFFExBPWrVt3wDlXOtDPpRwGZuYHfgJcAdQBb5jZSufcuz1W2wF83Dl3yMyuBpYDF8b77smTJ1NbW5tqFUVEPMPMPkzmc+loJpoDbHPObXfOdQCPA4t6ruCc+5Nz7lDk5Z+B6jSUKyIiaZKOMKgCdvV4XRdZFst/A55LQ7kiIpIm6bhmYFGWRR3jwszmEQ6DS2J+mdliYDHApEmT0lA9ERGJJx1nBnXAxB6vq4H63iuZ2WzgEWCRc64x1pc555Y752qcczWlpQO+BiIiIklIRxi8AUwzsylmlgfcBKzsuYKZTQKeBL7onHs/DWWKiEgapdxM5JzrMrPbgOcJdy191Dm3ycxujbz/MLAMGA88ZGYAXc65mlTLjmrjClhzLzTXQVE1zF8Gs28YlKJERLKFDechrGtqatyAupZuXAHPLIHO1pPLcgNw7YMKBBHxBDNbl8zBdnbdgbzm3lODAMKv19ybmfqIiIwQ2RUGzXUDWy4iIkC2hUFRjHvZYi0XEREg28Jg/rLwNYKecgPh5SIiElN2hcHsG+DaB2nKnUAIg6KJungsIpKAtIxaOqzMvoFfHfooP3juPTbe+QkKC3IzXSMRkWEvu84MIqqKw01F9U2tcdYUERHI0jCoDCoMREQGIivDoDoSBrsPKQxERBKRlWFQMiafPL+P3U1tma6KiMiIkJVh4PMZFcECdquZSEQkIVkZBgCVRQFdMxARSVDWhkFVcUDXDEREEpS1YVAZDLDvSBud3aFMV0VEZNjL2jCoDgZwDvY26yKyiEg8WRsGx+810EVkEZH4sjYMjt+FrOsGIiLxZW0YVBQVADozEBFJRNaGQUGun5Ix+epeKiKSgKwNA4h0L1UYiIjEld1hoLuQRUQSkuVhEL4L2TmX6aqIiAxraQkDM7vKzLaY2TYzuzPK+2ZmD0be32hm56ej3HgqgwHaOkMcPNYxFMWJiIxYKYeBmfmBnwBXAzOBz5nZzF6rXQ1Mi/wtBn6aarmJqNK9BiIiCUnHmcEcYJtzbrtzrgN4HFjUa51FwL+5sD8DQTOrSEPZ/dIkNyIiiUlHGFQBu3q8rossG+g6AJjZYjOrNbPahoaGlCpWHbnxrE43nomI9CsdYWBRlvW+YpvIOuGFzi13ztU452pKS0tTqlhRIJdReX7qNcmNiEi/0hEGdcDEHq+rgfok1kk7M6MqGGB3U8tgFyUiMqKlIwzeAKaZ2RQzywNuAlb2Wmcl8KVIr6K5QLNzbk8ayo6rMhjQmYGISBw5qX6Bc67LzG4Dngf8wKPOuU1mdmvk/YeBVcBCYBvQAnw51XITVVUc4O3dzUNVnIjIiJRyGAA451YR3uH3XPZwj+cO+Fo6yhqoqmCAg8c6aO3oJpDnz0QVRESGvay+Axl0r4GISCKyPgx0r4GISHxZHwYnJrlRGIiIxJT1YTBhbD5+n2nGMxGRfmR9GOT4fZQXFqiZSESkH1kfBgCVwQLqFAYiIjF5IgyOz2sgIiLReSIMKoMB9ja30R3SJDciItF4IgyqigN0hRz7j2hYChGRaLwRBsdvPFOPIhGRqLwVBrpuICISlSfCoFJhICLSL0+Ewej8HIKjctWjSEQkBk+EAYSbinTNQEQkOs+EgSa5ERGJzTNhEJ7+spXw1AoiItKTp8LgaHsXh9u6Ml0VEZFhxzthUKx7DUREYvFMGKh7qYhIbJ4JgyrNeCYiEpNnwmD86Dzycnw6MxARiSKlMDCzcWa22sy2Rh6Lo6wz0cxeNLPNZrbJzG5Ppcxk+Xx2okeRiIicKtUzgzuBNc65acCayOveuoBvOufOAuYCXzOzmSmWm5TKYIEuIIuIRJFqGCwCHos8fwy4rvcKzrk9zrk3I8+PAJuBqhTLTYomuRERiS7VMJjgnNsD4Z0+UNbfymY2GTgPWJtiuUmpDAbYf6Sd9q7uTBQvIjJs5cRbwcxeAMqjvLV0IAWZ2RjgCeAbzrnD/ay3GFgMMGnSpIEUEdfxHkV7m9s4bfzotH63iMhIFjcMnHMLYr1nZvvMrMI5t8fMKoD9MdbLJRwEv3TOPRmnvOXAcoCampq0jh3Rc5IbhYGIyEmpNhOtBG6JPL8FeLr3CmZmwM+Bzc65H6VYXkpO3IWs6wYiIqdINQzuA64ws63AFZHXmFmlma2KrHMx8EXgcjPbEPlbmGK5SSkvKgAUBiIivcVtJuqPc64RmB9leT2wMPL8VcBSKSdd8nP8lI3NV48iEZFePHMH8nGVuvFMRKQPz4VBVbEmuRER6c1zYVAdOTMIhTTJjYjIcZ4Lg8pggI6uEI3HOjJdFRGRYcNzYVCleQ1ERPrwXBhUBjXjmYhIb54Lg+M3nql7qYjISZ4Lg8KCHMbk56iZSESkB8+FgZkmuRER6c1zYQCa5EZEpDdPhkFVcYD6ZoWBiMhxngyDymCAppZOjrV3ZboqIiLDgifD4Pi9BupRJCIS5ukwqFMYiIgAXg0D3WsgInIKT4ZB2dgCcnymHkUiIhGeDAO/zygvKtCZgYhIhCfDADTJjYhIT54Ng+qgJrkRETnOs2FQGQyw93AbXd2hTFdFRCTjPBsGVcUBukOOfUfaM10VEZGM82wYaF4DEZGTUgoDMxtnZqvNbGvksbifdf1mtt7MfptKmelycsazlgzXREQk81I9M7gTWOOcmwasibyO5XZgc4rlpc3JISl0EVlEJNUwWAQ8Fnn+GHBdtJXMrBr4JPBIiuWlTSDPz7jRedSpmUhEJOUwmOCc2wMQeSyLsd6Pgf8BxO26Y2aLzazWzGobGhpSrF7/qoIB3XgmIgLkxFvBzF4AyqO8tTSRAszsGmC/c26dmV0Wb33n3HJgOUBNTY1LpIxkVQYL+EvDscEsQkRkRIgbBs65BbHeM7N9ZlbhnNtjZhXA/iirXQx8yswWAgVAoZn9P+fcF5KudZpUBUfxx60HcM5hZpmujohIxqTaTLQSuCXy/Bbg6d4rOOfucs5VO+cmAzcBfxgOQQDhM4OWjm6aWjozXRURkYxKNQzuA64ws63AFZHXmFmlma1KtXKDrbr4ePdSXTcQEW+L20zUH+dcIzA/yvJ6YGGU5S8BL6VSZjqduPGsqZVZVUUZro2ISOZ49g5k0PSXIiLHeToMxo3OoyDXpyEpRMTzPB0GZkZlMEB9s8JARLzN02EA4aYinRmIiNcpDIIBdmt8IhHxOM+HQWUwwIGj7bR1dme6KiIiGeP5MDjeo2hPs84ORMS7PB8GmuRGRERh0OMuZE1yIyLe5fkwmFBYgBm6iCwinub5MMjL8TFhbIGaiUTE0zwfBhAevVRDUoiIlykMgKriURq5VEQ8TWFA+MxgT3MrodCgTqwmIjJsKQyA6mCAzm5Hw9H2TFdFRCQjFAZAlSa5ERGPUxigG89ERBQGaJIbERGFATC2IJexBTlqJhIRz1IYRFQFAzozEBHPUhhEVAUD1OmagYh4VEphYGbjzGy1mW2NPBbHWC9oZr82s/fMbLOZXZRKuYOhqlhnBiLiXameGdwJrHHOTQPWRF5H8wDwO+fcDOAjwOYUy027S9teZFXoq7h7gnD/LNi4ItNVEhEZMqmGwSLgscjzx4Dreq9gZoXApcDPAZxzHc65phTLTa+NK7js/X+k2ncAw0HzLnhmiQJBRDwj1TCY4JzbAxB5LIuyzlSgAfg/ZrbezB4xs9Eplptea+4lp7vXENadrbDm3szUR0RkiMUNAzN7wczeifK3KMEycoDzgZ86584DjhG7OQkzW2xmtWZW29DQkGARKWquG9hyEZEskxNvBefcgljvmdk+M6twzu0xswpgf5TV6oA659zayOtf008YOOeWA8sBampqhmbkuKLqcNNQtOUiIh6QajPRSuCWyPNbgKd7r+Cc2wvsMrPpkUXzgXdTLDe95i+D3MCpy3ID4eUiIh6QahjcB1xhZluBKyKvMbNKM1vVY72vA780s43AucD3Uyw3vWbfANc+SPvoKkLOaAlUwLUPhpeLiHiAOTd8x/CvqalxtbW1Q1Zed8hR84+ruWx6GfffeO6QlSsiki5mts45VzPQz+kO5B78PuPjZ5by8vsNdGuiGxHxEIVBL/NmlHHwWAcb64bXrRAiIoNJYdDLpdNK8Rm8+F60jlEiItlJYdBL8eg8zptUzItbhugeBxGRYUBhEMW86aW8vbuZ/Ufa4q8sIpIFFAZRzJsRHlXjZZ0diIhHKAyimFlRSNnYfF5SGIiIRygMojAz5k0v45X3G+jsDmW6OiIig05hEMO8GaUcae9i3YeHMl0VEZFBpzCI4eIzSsj1Gy9uURdTEcl+CoMYxhbkcsHkcbz0nq4biEj2Uxj0Y970MrbsO8JuzY0sIllOYdCPeTNKAd2NLCLZT2HQj9NLx1BdHOAlXTcQkSynMOjH8S6mr21rpK2zO9PVEREZNAqDOC6fUUZrZzev7ziY6aqIiAwahUEcc6eOJz/Hpy6mIpLVFAZxBPL8XHT6eF1EFpGspjBIwLzpZXzQ2MKOA8cyXRURkUGhMEjAvOnhUUx1diAi2UphkIBJ40dxeuloXTcQkaylMEjQvOllrN1+kJaOrkxXRUQk7VIKAzMbZ2arzWxr5LE4xnp3mNkmM3vHzP7DzApSKTcT5s0oo6M7xGvbGjNdFRGRtEv1zOBOYI1zbhqwJvL6FGZWBSwBapxzswA/cFOK5Q65CyaPY3SeX01FIpKVUg2DRcBjkeePAdfFWC8HCJhZDjAKqE+x3CGXl+PjkmklvPTefpxzma6OiEhapRoGE5xzewAij2W9V3DO7Qb+F7AT2AM0O+d+n2K5GTFvehn1zW28v+9opqsiIpJWccPAzF6ItPX3/luUSAGR6wiLgClAJTDazL7Qz/qLzazWzGobGobXXAKXHe9iqqYiEckyccPAObfAOTcryt/TwD4zqwCIPEbbSy4AdjjnGpxzncCTwMf6KW+5c67GOVdTWlqa3L9qkJQXFXBWRSF/0P0GIpJlUm0mWgncEnl+C/B0lHV2AnPNbJSZGTAf2JxiuRkzb3op6z48RHNrZ6arIiKSNqmGwX3AFWa2Fbgi8hozqzSzVQDOubXAr4E3gbcjZS5PsdyMuXxGGd0hx6tbD2S6KiIiaZOTyoedc42Ej/R7L68HFvZ4fTdwdyplDRfnTgxSFMjlxS37+eTsikxXR0QkLXQH8gDl+H1cemYpL21pIBRSF1MRyQ4KgyTMm17KgaPtvFPfnOmqiIikhcIgCR8/sxQzePG94dX1VUQkWQqDJIwfk89HqoO630BEsobCIEnzppfxVl0TjUfbM10VEZGUKQySNG9GKc7BK1vVVCQiI5/CIEmzKosoGZPPH3TdQESygMIgST6fcdn0Ul55v4Gu7lCmqyMikhKFQQrmTS+jubWTDbuaMl0VEZGUKAxSMK/jJV7LX8JH/+9UuH8WbFyR6SqJiCQlpeEoPG3jCkY9fwejrDX8unkXPLMk/Hz2DZmrl8hIsXEFrLkXmuugqBrmL9P/OxmkM4NkrbkXOltPXdbZGl4uIv3buCJ88NS8C3AnD6Z0dp0xCoNkNdcNbLmInJTKwdTGFeFm2XuC2dc8m8F/m8IgWUXVA1suIiclezA11GcUye6ck/lchs+WFAbJmr8McgOnLGoln5a/WpqhComMIMkeTA3lGUWyO+con3PPLKHjzcc53NbJoWMd7D/SRn1TKzsbW9jecJT39x2h4/f3ZLTpWReQk3X8QlfkAljHmEruarqOgg/P5r6azFZNZNibvyy8w+y588sNhJf3J4kzCuccHet/Rd6qb2BdJzt8dD+9hC17DrOz6hrau7pp6+ymrTNEW2c37V0hbln79xRF2TkfeHop33j9NDq6Q3R0hf86u0N0dIfo7ArxRPtdVHDq56yzlf2/WcolK8bGrOf2/N1gA/u3pZPCIBWzbzgRCnnAhOc287OXt/Opcyv52Oklma2byFBJpldQr4OpaJ9r6+zmcGsnh9s6aW7t4nBbJxcGyhnVuqfP1zXmlPG3j75OS0cXx9q7w48d3bS0d9HS2c0fc5dS7Tt1B+3vbqXwtR9wa0f0Sapuy98bdec8rruBlo4u8nJ8jC3IIT/HR67fR17ksXxTY9Tvq/I18p1PnkWOz/D7feT6jBy/jxyfkeM32n9XSaClvu8Hh6jp2ZwbvhO01NTUuNra2kxXI2Ftnd1c+eNXAHj+G5dSkOvPcI1EBtnxJpHeR/jXPnhix97VHeJQSycHj3XQeKw9/Hi0g8ZjHRw81k5TSyeH27pO7PgPR3b8HV197+z/lO9V7st9hFHWcWJZK/ncX/A11o5dwOg8P6PychidH3nM8zMqP4c7XpuD0Xdf5zDeXfwhBbn+8F+Oj/zIY86DsyNNPb0UTYQ73om9Te6fldznEtiWiTCzdc65AbdP6MwgjQpy/fzg0+fw+X9dy49f2MqdV8/IdJVEEjeAI/zukKPxaDvB399DXpSmlIbfLOXG1WUcPNZBc2sn0Y45zSAYyCU4Ko/CQC6FBTlUFQcoLMilKJBLYSCHwoLcE++FHz9O5wezCL36fXyHd0NRNYH5y/h2vJ3lO9VRd9BWVM3ZlUXRP5NsU1ayn0vgbGkwKQzS7GOnl3BjzUT+9Y/buWZ2BbOqYvzQRIaT3kelkTb1Nz84xLqiBextbmPf4Tb2Hm5jb3Mb+4+00x1yMdu5x4caOKu8kHGj8xg3Oo/xY/JOPh+dz7jReRSPyiXHn0QflrKbYc7NA/tMMjvoZHfOqezUezQ9DzU1Ew2C5pZOFtz/MmVj83n6axcn94MXSVacI/xQyLHvSBsfNraw82ALuw628OXXr2Vc174+X1UXKuGSjgcZk59DeVEB5YUFTCgsoLwon/LCAj7zx6tjtHPHaRLJBI/c8ZxsM5HCYJA89/YevvLLN7nr6hn894+fnunqyEg10B1YlHbnTl8Bv5n4dzzLJew82ELdwVY6eoy06zPYln8zvhht6sfuOsCY/BiNCGlq55b0ycg1AzP7LHAPcBYwxzkXdc9tZlcBDwB+4BHn3H2plDsSXH1OBVeePYEfrX6fK88uZ3LJ6ExXSUaaKE03vce/OtLWyV8ajrF13xG2NRzlb2qXUtJ9aht+bqiNiz/8CY+Nv4AZ5WO5YuYEJo0bdeKvMhjA92DsNvWYQdCjHl444s52KZ0ZmNlZQAj4GfCtaGFgZn7gfeAKoA54A/icc+7deN8/ks8MAPYdbmPBD19mVlUR//43F2IWrROxSAwxeqU05U3g6xN+wbb9R9nT3HZieZ7fx3u5n4t6hA8G9/Qz1LqO8LNGRs4MnHObI4X3t9ocYJtzbntk3ceBRUDcMBjpJhQWcNfCs/j2U2+zonYXN14wKdNVkkxJsLknFHLsaDzGu/WHuaa5Luo9SIXt+2lq6eSiqeM5vWwM08rGcEbZGCaNGxXzCD9uX3Ud4XveUPQmqgJ6/jrrgAtjrWxmi4HFAJMmjfyd500XTOTpDbv53rObmTe9jLLCgkxXSYZajOaezlCILaVXs6m+mU31h9lUf5jNew7T0tENwPn546myA32+zoLVPPP1S6KXlWy3RshoTxbJvLhhYGYvAOVR3lrqnHs6gTKiHdzEbJtyzi0HlkO4mSiB7x/WfD7jB58+h6se+CP3PLOJh27+aKarJEMtxng6+59ayjXt4eEJRuf5mVlZyA01E5lZWcjZlYVM2P99ePb2Pjt2G4zukOJ5ccPAObcgxTLqgIk9XlcDUfqiZa+ppWO4ff40/vn5LTy/aS9Xnh0tW2VESKC5xznHB40trN95iPU7m/huc13UESErrZF/+fx5nF1ZxGnjRuHz9Tpuqrwx3NUnmX7u2vnLAA1FM9EbwDQzmwLsBm4CPj8E5Q4riy+dym837uHvf/MOc6eOpyiQm+kqyUDFaO5p6eimtnAB63c2sX7XITbsaqKppRMIH/EvyS2ltHt/n6+zomqumV3Zf5nascsQSbVr6fXA/wZKgWfNbINz7kozqyTchXShc67LzG4DnifctfRR59ymlGs+wuT6ffzTfzmH637yGv/0u/f4/vXnZLpKMlAxmnsOrvwOX+ooxAymlY3hypnlnDcpyHmTijmjbAz+d76XfDu+yBBJtTfRU8BTUZbXAwt7vF4FrEqlrGwwuzrIX//VVJa/sp1PfaSSuVPHZ7pKEkdHV4i3dzfx+o5D3Bqjd0+Vr5Ff/vWFzK4uYmxBlDM+tePLCKCxiYbYHQvOpGv9r5j8i9tx7gCmHUNmxGj7P9rexboPD1H7wUFe33GQDbuaaI+Mnnl9oIRy19Dnq6yomovPiDNkuZp7ZJhTGAyxwHtPsDT0MH4X+65SGWRR2v47nrqNB55/j58e/CghB36fcXZlIV+YexoXTC6mZvI4SrZ/X809krUUBkNtzb34u2NMbacwGHT7D7cx5rm7GdWr7T/PtfNf236Bf96NXDBlHOdNKu47DIOaeySLKQyGWowp7FyM9miJI05Xz73Nbazd0ciftzeydvtBth84xvb8+qh3v5R2N/C3n5jef3lq7pEspTAYakXRhwvY7cbzi+c2c8eCMzVDWqKiNPeEVi5h3QcH+XXHx1i7o5EPGlsAGFuQw5zJ4/jcnEl0vV5F3tHdfb9viKYXFBmOFAZDLcpwAS4nwKsVX+FnL2/nD5v388MbPsLs6mAGKzkyuDX3Yr2ae3xdrVTU/jPP+R5izpTxfGHuacydOp6zKgrxH7+pK3iP2v5FelEYDLUo7c42fxk3zb6B8i37ufOJt7n+oT/x1ctO5+uXTyMvRxPjHOec4y8NR1m7I9zT5/5+unquX/aJkzv/3tT2L9KHJrcZZppbO/nuM5t48s3dnFVRyA8/+xFmVhZmulqDL0rbf/esz/Le3sO8Htn5v77jII3HwhOhl47N53fuq4yPMjvXsJxlS2SIaKazLLP63X3c9eTbNLd2sOTyadx62enkZuv0mVHG0m+3fJa5xfyq7SIAqosDzJkyjgunjGPOlPFMHj8Ke/s/NQa/SC8Kgyx06FgHy1Zu4pm36jmnqojl526novZ/ZkXThnOODxtb2LCrictWzSPY2fcI/1DuBF5e+CIXTBlHVTAQ/Ys8Mq+tSKIUBlns2Y17eO2ph/hO6GFGWcfJN4brUXCUHfSh069jQ10TG3Y2sWFXE2/VnRzMbXv+zfgsidm5RKSPjMx0JkPjk7MruGr1k/iPdJz6Rmcrnb+/B/+sz/Yd/jhTNq7ArVyCdZ3s7tn25G3c3bGelaFL8BmcOWEsV84s59xJQc6dGMQer4p+/4W6eooMGYXBCOE/EqVfPOA/Us95/7CacycGT4yUee7E4KlDZCfblNLP59q7utnZ2BK+iavhGDsOHGXHgWM8sPcuKjm1u2cB7Xxv7FN87oZvcU51Ud87e+ffra6eIhmmMBgpYtys1jqqnIXTynnzwyYeWLOV461+Z5SN4byJQa7P+RNzN30XX1f/YyGFQo7OUIjObkdnVwjfO//J2NXfPOVzHU/dxqMv/4V/b51L3aEWQj1adkrG5DO1dDQVNEat/tj2vVx0eoxRWtXVUyTjdM1gpIjS46b3NYMjbZ1srGtm/c5DvLmzifU7D/FM11eo9vWdR7eeEq7kITq7wwHQHTr1d/Bq3pKon9vnK+UfzljB1JLRTC0dw5SS0UwpHU3h8aGb758VY0J2dfcUGQq6ZpDtEjh6HluQy8VnlJwYTtk5B9+NfqReQSOf+Wg1uX4fuX6LPJ58XrU6+ucmhA7wL58/P3Y9U5mQXUQyRmEwkgxwkDQzi9m8ZEXV3H3t2bE//Hr0z8W9qKsmH5ERSWGQ7ZI9Uk/lCF8je4qMOFl6S6ucMPuG8HWFoomAhR8TuTch2c+JyIikC8giIlkk2QvIOjMQEZHUwsDMPmtmm8wsZGZRk8jMJprZi2a2ObLu7amUKSIi6ZfqmcE7wKeBV/pZpwv4pnPuLGAu8DUzm5liuSIikkYp9SZyzm2GSBfG2OvsAfZEnh8xs81AFfBuKmWLiEj6DOk1AzObDJwHrB3KckVEpH9xzwzM7AWgPMpbS51zTydakJmNAZ4AvuGcO9zPeouBxZGXR81sS6JljEAlQN8xH7xN2yQ6bZe+tE36KgFOS+aDaelaamYvAd9yzkXtB2pmucBvgeedcz9KucAsYWa1yXQBy2baJtFpu/SlbdJXKttk0JuJLHxB4efAZgWBiMjwlGrX0uvNrA64CHjWzJ6PLK80s1WR1S4GvghcbmYbIn8LU6q1iIikVaq9iZ4CnoqyvB5YGHn+KjBMpuEadpZnugLDkLZJdNoufWmb9JX0NhnWw1GIiMjQ0HAUIiKiMBgKZnaVmW0xs21mdmeU9y8zs+Ye11SyfiYYM3vUzPabWdTpzyzswcg222hm/cyokx0S2CZe/J3EHc7Ga7+VBLfJwH8rzjn9DeIf4Af+AkwF8oC3gJm91rkM+G2m6zrE2+VS4HzgnRjvLwSeI3y9aS6wNtN1HgbbxIu/kwrg/MjzscD7Uf7/8dRvJcFtMuDfis4MBt8cYJtzbrtzrgN4HFiU4TplnHPuFeBgP6ssAv7Nhf0ZCJpZxdDULjMS2Cae45zb45x7M/L8CHB8OJuePPVbSXCbDJjCYPBVAT3nj6wj+n+4i8zsLTN7zsz6mY/SMxLdbl7j2d9JP8PZePa3EmeInwH9VrzrtsUAAAFESURBVDTt5eCL1q22dxeuN4HTnHNHI/dg/AaYNug1G94S2W5e49nfSZzhbDz5W4mzTQb8W9GZweCrAyb2eF0N1PdcwTl32Dl3NPJ8FZBrZiVDV8VhKe528xqv/k4iw9k8AfzSOfdklFU891uJt02S+a0oDAbfG8A0M5tiZnnATcDKniuYWXlk2A7MbA7h/y6NQ17T4WUl8KVIT5G5QLMLD4fuWV78nSQ4nI2nfiuJbJNkfitqJhpkzrkuM7sNeJ5wz6JHnXObzOzWyPsPA58BvmJmXUArcJOLdAnIVmb2H4R7PJREhjS5G8iFE9tkFeFeItuAFuDLmanp0Elgm3jud8LJ4WzeNrMNkWXfBiaBZ38riWyTAf9WdAeyiIiomUhERBQGIiKCwkBERFAYiIgICgMREUFhICIiKAxERASFgYiIAP8fW4n7tKaxGicAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from blueqat import *\n",
+    "from openfermion import *\n",
+    "from openfermionblueqat import*\n",
+    "import numpy as np\n",
+    "\n",
+    "def get_molecule(bond_len):\n",
+    "  geometry = [('H',(0.,0.,0.)),('H',(0.,0.,bond_len))]\n",
+    "\n",
+    "  description = format(bond_len)\n",
+    "  molecule = MolecularData(geometry, \"sto-3g\",1,description=description)\n",
+    "\n",
+    "  molecule.load()\n",
+    "  return molecule\n",
+    "\n",
+    "x = [];e=[];fullci=[]\n",
+    "for bond_len in np.arange(0.2,2.5,0.1):\n",
+    "  m = get_molecule(\"{:.2}\".format(bond_len))\n",
+    "  h = bravyi_kitaev(get_fermion_operator(m.get_molecular_hamiltonian()))\n",
+    "  runner = vqe.Vqe(UCCAnsatz(h,6,Circuit().x[0]))\n",
+    "  result = runner.run()\n",
+    "  x.append(bond_len)\n",
+    "  e.append(runner.ansatz.get_energy_sparse(result.circuit))\n",
+    "  fullci.append(m.fci_energy)\n",
+    "\n",
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "plt.plot(x,fullci)\n",
+    "plt.plot(x,e,\"o\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "102vqe_qaoa02.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/tutorial-ja/601_optimizer_ja.ipynb
+++ b/tutorial-ja/601_optimizer_ja.ipynb
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 1,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -91,7 +91,7 @@
      "output_type": "stream",
      "text": [
       "Result by VQE\n",
-      "-7.99999996077787\n",
+      "-7.999999839073751\n",
       "Result by numpy\n",
       "-8.0\n"
      ]
@@ -120,7 +120,7 @@
     "result = runner.run()\n",
     "\n",
     "print('Result by VQE')\n",
-    "print(runner.ansatz.get_energy(result.circuit, runner.sampler))\n",
+    "print(runner.ansatz.get_energy_sparse(result.circuit))\n",
     "\n",
     "# Hamiltonian to matrix\n",
     "mat = h.to_matrix()\n",
@@ -143,14 +143,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 2,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
      "height": 170
     },
     "colab_type": "code",
-    "collapsed": true,
     "id": "aV8SOqfRaAl3",
     "outputId": "717e0578-246f-4b7c-8bd7-dbfc02e605a6"
    },
@@ -159,17 +158,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Requirement already satisfied: hyperopt in /home/ec2-user/anaconda3/envs/python3/lib/python3.6/site-packages (0.2.4)\n",
-      "Requirement already satisfied: cloudpickle in /home/ec2-user/anaconda3/envs/python3/lib/python3.6/site-packages (from hyperopt) (0.5.3)\n",
-      "Requirement already satisfied: six in /home/ec2-user/anaconda3/envs/python3/lib/python3.6/site-packages (from hyperopt) (1.11.0)\n",
-      "Requirement already satisfied: numpy in /home/ec2-user/anaconda3/envs/python3/lib/python3.6/site-packages (from hyperopt) (1.18.3)\n",
-      "Requirement already satisfied: networkx>=2.2 in /home/ec2-user/anaconda3/envs/python3/lib/python3.6/site-packages (from hyperopt) (2.4)\n",
-      "Requirement already satisfied: scipy in /home/ec2-user/anaconda3/envs/python3/lib/python3.6/site-packages (from hyperopt) (1.1.0)\n",
-      "Requirement already satisfied: tqdm in /home/ec2-user/anaconda3/envs/python3/lib/python3.6/site-packages (from hyperopt) (4.45.0)\n",
-      "Requirement already satisfied: future in /home/ec2-user/anaconda3/envs/python3/lib/python3.6/site-packages (from hyperopt) (0.18.2)\n",
-      "Requirement already satisfied: decorator>=4.3.0 in /home/ec2-user/anaconda3/envs/python3/lib/python3.6/site-packages (from networkx>=2.2->hyperopt) (4.3.0)\n",
-      "\u001b[33mWARNING: You are using pip version 20.0.2; however, version 20.1 is available.\n",
-      "You should consider upgrading via the '/home/ec2-user/anaconda3/envs/python3/bin/python -m pip install --upgrade pip' command.\u001b[0m\n"
+      "Collecting hyperopt\n",
+      "  Downloading hyperopt-0.2.4-py2.py3-none-any.whl (964 kB)\n",
+      "\u001b[K     |████████████████████████████████| 964 kB 8.8 MB/s eta 0:00:01\n",
+      "\u001b[?25hCollecting cloudpickle\n",
+      "  Downloading cloudpickle-1.4.1-py3-none-any.whl (26 kB)\n",
+      "Requirement already satisfied: networkx>=2.2 in /home/penguin/quantumlibs/lib/python3.8/site-packages (from hyperopt) (2.4)\n",
+      "Requirement already satisfied: six in /usr/lib/python3.8/site-packages (from hyperopt) (1.15.0)\n",
+      "Requirement already satisfied: future in /usr/lib/python3.8/site-packages (from hyperopt) (0.18.2)\n",
+      "Requirement already satisfied: tqdm in /usr/lib/python3.8/site-packages (from hyperopt) (4.46.0)\n",
+      "Requirement already satisfied: scipy in /usr/lib/python3.8/site-packages (from hyperopt) (1.4.1)\n",
+      "Requirement already satisfied: numpy in /usr/lib/python3.8/site-packages (from hyperopt) (1.18.4)\n",
+      "Requirement already satisfied: decorator>=4.3.0 in /usr/lib/python3.8/site-packages (from networkx>=2.2->hyperopt) (4.4.2)\n",
+      "Installing collected packages: cloudpickle, hyperopt\n",
+      "Successfully installed cloudpickle-1.4.1 hyperopt-0.2.4\n"
      ]
     }
    ],
@@ -179,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 3,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -197,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 4,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -212,9 +214,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:01<00:00, 88.83trial/s, best loss: -7.995049681622847] \n",
+      "100%|██████████| 100/100 [00:00<00:00, 206.96trial/s, best loss: -7.990075559549002]\n",
       "Result by VQE\n",
-      "-7.995049681622847\n",
+      "-7.990075559549002\n",
       "Result by numpy\n",
       "-8.0\n"
      ]
@@ -225,7 +227,7 @@
     "result = runner.run()\n",
     "\n",
     "print('Result by VQE')\n",
-    "print(runner.ansatz.get_energy(result.circuit, runner.sampler))\n",
+    "print(runner.ansatz.get_energy_sparse(result.circuit))\n",
     "\n",
     "# Hamiltonian to matrix\n",
     "mat = h.to_matrix()\n",
@@ -252,9 +254,9 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "conda_python3",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda_python3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -266,7 +268,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/tutorial/106_vqe_qaoa06.ipynb
+++ b/tutorial/106_vqe_qaoa06.ipynb
@@ -1,546 +1,558 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "106_vqe_qaoa06.ipynb",
-      "provenance": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "ZnODbF2Hyrre"
+   },
+   "source": [
+    "#Traffic flow optimization without constraint term on quantum computing using quantum alternating operator ansatz"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ZnODbF2Hyrre",
-        "colab_type": "text"
-      },
-      "source": [
-        "#Traffic flow optimization without constraint term on quantum computing using quantum alternating operator ansatz"
-      ]
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "j392IPADyrh0"
+   },
+   "source": [
+    "##Quantum Alternating Operator Ansatz\n",
+    "Here think about how to rise up the accuracy of optimization problems on quantum computing.\n",
+    "\n",
+    "One of this answer is to use Quantum Alternating Operator Ansatz for QAOA. It can reduce the number of constraint term in the qubo formulation.\n",
+    "\n",
+    "By adopting XX+YY gate, the time evolution can operate a swap of 01 and 10. This achieve a good operation on combinatorial optimization problem if we know that 00 and 11 not appear in the result from first.\n",
+    "\n",
+    "<img src=\"https://qiita-user-contents.imgix.net/https%3A%2F%2Fqiita-image-store.s3.ap-northeast-1.amazonaws.com%2F0%2F88256%2F0b4a9d82-8ebf-8191-23d7-dbb76396e9d1.png?ixlib=rb-1.2.2&auto=format&gif-q=60&q=75&w=1400&fit=max&s=616a52dfc97ba36e01aba646f9affdac\">\n",
+    "\n",
+    "reference: https://qiita.com/gyu-don/items/c51a9e3d5d16a6d5baf6\n",
+    "\n",
+    "Let's solve a simple problem using this technique\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "KnFuYDDZy9p-"
+   },
+   "source": [
+    "\n",
+    "##Example\n",
+    "Here we try a simple hamiltonian of\n",
+    "\n",
+    "```python\n",
+    "h = -3*q(0)-3*q(1)-2*q(0)*q(1)\n",
+    "```\n",
+    "\n",
+    "The minimum answer is the combination of (1,1) and this hamiltonian takes minimum value as -8.\n",
+    "\n",
+    "Now we use the entanglement on the initial state of |10> and |01>. And use XY mixer as a driver hamiltonian of time evolution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 136
     },
+    "colab_type": "code",
+    "id": "wG4hCQkBzLj-",
+    "outputId": "bd14daa7-3acd-47da-e13e-8353adf15763"
+   },
+   "outputs": [
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "j392IPADyrh0",
-        "colab_type": "text"
-      },
-      "source": [
-        "##Quantum Alternating Operator Ansatz\n",
-        "Here think about how to rise up the accuracy of optimization problems on quantum computing.\n",
-        "\n",
-        "One of this answer is to use Quantum Alternating Operator Ansatz for QAOA. It can reduce the number of constraint term in the qubo formulation.\n",
-        "\n",
-        "By adopting XX+YY gate, the time evolution can operate a swap of 01 and 10. This achieve a good operation on combinatorial optimization problem if we know that 00 and 11 not appear in the result from first.\n",
-        "\n",
-        "<img src=\"https://qiita-user-contents.imgix.net/https%3A%2F%2Fqiita-image-store.s3.ap-northeast-1.amazonaws.com%2F0%2F88256%2F0b4a9d82-8ebf-8191-23d7-dbb76396e9d1.png?ixlib=rb-1.2.2&auto=format&gif-q=60&q=75&w=1400&fit=max&s=616a52dfc97ba36e01aba646f9affdac\">\n",
-        "\n",
-        "reference: https://qiita.com/gyu-don/items/c51a9e3d5d16a6d5baf6\n",
-        "\n",
-        "Let's solve a simple problem using this technique\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "KnFuYDDZy9p-",
-        "colab_type": "text"
-      },
-      "source": [
-        "\n",
-        "##Example\n",
-        "Here we try a simple hamiltonian of\n",
-        "\n",
-        "```python\n",
-        "h = -3*q(0)-3*q(1)-2*q(0)*q(1)\n",
-        "```\n",
-        "\n",
-        "The minimum answer is the combination of (1,1) and this hamiltonian takes minimum value as -8.\n",
-        "\n",
-        "Now we use the entanglement on the initial state of |10> and |01>. And use XY mixer as a driver hamiltonian of time evolution."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "wG4hCQkBzLj-",
-        "colab_type": "code",
-        "outputId": "bd14daa7-3acd-47da-e13e-8353adf15763",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 136
-        }
-      },
-      "source": [
-        "!pip install blueqat"
-      ],
-      "execution_count": 0,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Collecting blueqat\n",
-            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/f6/73/20f9cff48caee1f69190f2e1ea93c4d7d0a745fc48defb5d3072d8337583/blueqat-0.3.13-py3-none-any.whl (50kB)\n",
-            "\r\u001b[K     |██████▌                         | 10kB 21.3MB/s eta 0:00:01\r\u001b[K     |█████████████                   | 20kB 1.8MB/s eta 0:00:01\r\u001b[K     |███████████████████▍            | 30kB 2.6MB/s eta 0:00:01\r\u001b[K     |█████████████████████████▉      | 40kB 1.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████████████| 51kB 1.7MB/s \n",
-            "\u001b[?25hRequirement already satisfied: numpy~=1.12 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.17.5)\n",
-            "Requirement already satisfied: scipy>=1.1.0 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.4.1)\n",
-            "Installing collected packages: blueqat\n",
-            "Successfully installed blueqat-0.3.13\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "A8bqofq7ynKG",
-        "colab_type": "code",
-        "outputId": "db644b72-f9db-48a0-fb42-46828d4f34d9",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 102
-        }
-      },
-      "source": [
-        "import numpy as np\n",
-        "from blueqat import Circuit\n",
-        "from blueqat.pauli import X, Y, Z, I\n",
-        "from blueqat.pauli import qubo_bit as q\n",
-        "from blueqat.vqe import AnsatzBase, Vqe\n",
-        "\n",
-        "def an(index):\n",
-        "    return 0.5 * X[index] + 0.5j * Y[index]\n",
-        "\n",
-        "def cr(index):\n",
-        "    return 0.5 * X[index] - 0.5j * Y[index]\n",
-        "\n",
-        "op = (cr(1) * an(0) + cr(0) * an(1)).to_expr().simplify()\n",
-        "\n",
-        "class QaoaQaoaAnsatz(AnsatzBase):\n",
-        "    def __init__(self, hamiltonian, step=1, init_circuit=None):\n",
-        "        super().__init__(hamiltonian, step * 2)\n",
-        "        self.hamiltonian = hamiltonian.to_expr().simplify()\n",
-        "        if not self.check_hamiltonian():\n",
-        "            raise ValueError(\"Hamiltonian terms are not commutable\")\n",
-        "\n",
-        "        self.step = step\n",
-        "        self.n_qubits = self.hamiltonian.max_n() + 1\n",
-        "        if init_circuit:\n",
-        "            self.init_circuit = init_circuit\n",
-        "            if init_circuit.n_qubits > self.n_qubits:\n",
-        "                self.n_qubits = init_circuit.n_qubits\n",
-        "        else:\n",
-        "            self.init_circuit = Circuit(self.n_qubits).h[:]\n",
-        "        self.init_circuit.make_cache()\n",
-        "        self.time_evolutions = [term.get_time_evolution() for term in self.hamiltonian]\n",
-        "        self.time_evolutions2 = [term.get_time_evolution() for term in op]\n",
-        "    def check_hamiltonian(self):\n",
-        "        \"\"\"Check hamiltonian is commutable. This condition is required for QaoaAnsatz\"\"\"\n",
-        "        return self.hamiltonian.is_all_terms_commutable()\n",
-        "\n",
-        "    def get_circuit(self, params):\n",
-        "        c = self.init_circuit.copy()\n",
-        "        betas = params[:self.step]\n",
-        "        gammas = params[self.step:]\n",
-        "        for beta, gamma in zip(betas, gammas):\n",
-        "            beta *= np.pi\n",
-        "            gamma *= 2 * np.pi\n",
-        "            for evo in self.time_evolutions:\n",
-        "                evo(c, gamma)\n",
-        "            for evo2 in self.time_evolutions2:\n",
-        "                evo2(c, beta)\n",
-        "        return c\n",
-        "\n",
-        "h = -3*q(0)-3*q(1)-2*q(0)*q(1)\n",
-        "h = h.to_expr().simplify()\n",
-        "runner = Vqe(QaoaQaoaAnsatz(h,4,Circuit().h[0].cx[0,1].x[0]))\n",
-        "result = runner.run()\n",
-        "\n",
-        "# get probability\n",
-        "print(result.most_common(12))\n",
-        "\n",
-        "print('Result by QAOA')\n",
-        "print(runner.ansatz.get_energy(result.circuit, runner.sampler))\n",
-        "\n",
-        "# Hamiltonian to matrix\n",
-        "mat = h.to_matrix()\n",
-        "\n",
-        "# Calculate by numpy\n",
-        "print('Result by numpy')\n",
-        "print(np.linalg.eigh(mat)[0][0])"
-      ],
-      "execution_count": 0,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "(((1, 0), 0.49999999999999883), ((0, 1), 0.49999999999999867), ((1, 1), 1.6023737137301796e-31), ((0, 0), 1.203706215242022e-31))\n",
-            "Result by QAOA\n",
-            "-2.999999999999993\n",
-            "Result by numpy\n",
-            "-8.0\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Pvz6c0zKzO43",
-        "colab_type": "text"
-      },
-      "source": [
-        "Numpy shows the minimum result as -8 but this QAOA has limitation of |01> or |10> as a result using entanglement and XYmixer. |00> or |11> doesn't appear in the result.\n",
-        "\n",
-        "Using this we can get much more accurate result on a specific problem with constraints.\n",
-        "\n",
-        "<img width=\"1281\" alt=\"スクリーンショット 2020-02-25 0.39.32.png\" src=\"https://qiita-image-store.s3.ap-northeast-1.amazonaws.com/0/218694/85efc267-c34d-dbc8-1bb0-25bc22cfb1c0.png\">"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "A9M2QO-Fzaa6",
-        "colab_type": "text"
-      },
-      "source": [
-        "##Traffic flow optimization without constraint term on quantum computing using quantum alternating operator ansatz\n",
-        "Here we adopted traffic flow optimization problem as a case study, but this technique is a general one and can be applied to a variety of problems.\n",
-        "\n",
-        "References\n",
-        "As a model we use traffic flow modeling from VW paper.\n",
-        "\n",
-        "Traffic flow optimization using a quantum annealer  \n",
-        "Florian Neukart, Gabriele Compostella, Christian Seidel, David von Dollen, Sheir Yarkoni, Bob Parney  \n",
-        "(Submitted on 4 Aug 2017 (v1), last revised 9 Aug 2017 (this version, v2))  \n",
-        "https://arxiv.org/pdf/1708.01625.pdf\n",
-        "\n",
-        "As an algorithm we use QAOA for universal gate model.  \n",
-        "A Quantum Approximate Optimization Algorithm  \n",
-        "Edward Farhi, Jeffrey Goldstone, Sam Gutmann  \n",
-        "https://arxiv.org/abs/1411.4028  \n",
-        "\n",
-        "And technique to use XY mixer.  \n",
-        "From the Quantum Approximate Optimization Algorithm to a Quantum Alternating   Operator Ansatz\n",
-        "Stuart Hadfield, Zhihui Wang, Bryan O’Gorman, Eleanor G. Rieffel, Davide Venturelli, Rupak Biswas  \n",
-        "https://arxiv.org/abs/1709.03489  \n",
-        "\n",
-        "And prepare an entangled state.  \n",
-        "Portfolio rebalancing experiments using the\n",
-        "Quantum Alternating Operator Ansatz  \n",
-        "Mark Hodson∗, Brendan Ruck∗, Hugh (Hui Chuan) Ong†, David Garvin∗, Stefan Dulman†\n",
-        "∗Rigetti Computing\n",
-        "†Commonwealth Bank of Australia  \n",
-        "https://arxiv.org/pdf/1911.05296.pdf"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ilMGpQ2kQOjq",
-        "colab_type": "text"
-      },
-      "source": [
-        "##Modeling and formulation\n",
-        "We use the model from the VW. We prepare start point A and goal point B. And named each street from s0 to s11.\n",
-        "\n",
-        "<img src=\"https://miro.medium.com/max/730/0*jdvbeWCvUMG-UKis\">\n",
-        "\n",
-        "Let’s prepare two cars and set possible route setting for each vehicles.\n",
-        "\n",
-        "car1  \n",
-        "route1-1(q0)：s0,s3,s6,s9  \n",
-        "route1–2 (q1)：s0,s3,s8,s11  \n",
-        "\n",
-        "car2  \n",
-        "route2–1(q2):s0,s3,s8,s11  \n",
-        "route2–2(q3):s2,s7,s10,s11\n",
-        "\n",
-        "q0 to q3 denote qubits. If the route selected the value of qubit is 1 else 0. If route1–1 is selected for car1 and route2–2 is selected for car2 the answer is, (1,0,0,1)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "_vb17KENQpaD",
-        "colab_type": "text"
-      },
-      "source": [
-        "Cost=(q0+q1+q2)²+(q0+q1+q2)²+q0²+q0²+(q1+q2)²+(q1+q2+q3)²+q3²+q3²+q3²=4q0+4q1+4q2+4q3+4q0q1+4q0q2+8q1q2+2q1q3+2q2q3\n",
-        "\n",
-        "And the constraint is that car1 select just 1route from q0 and q1. Car2 also select just one route from q2 and q3.\n",
-        "\n",
-        "Const=(q0+q1−1)²+(q2+q3−1)²=q0−q1−q2−q3+2q0q1+2q2q3+2\n",
-        "\n",
-        "Usually we connect these equation using variable K.\n",
-        "\n",
-        "Cost+K∗ConstCost+K∗Const\n",
-        "\n",
-        "Now we think about a new technique to remote this Const term."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "hsK9MfhHQ0w7",
-        "colab_type": "text"
-      },
-      "source": [
-        "##Prepare the initial state\n",
-        "Usually quantum annealing is searching the value almost randomly using sigmaX. And the initial state is |+> as the eigen state of hamiltonian X. As the mixer it is using time evolution of hamitonian X.\n",
-        "\n",
-        "But here we think about the pattern of searching. Each car always select just one route from the possible routes. So, just one of q0 or q1 is selected as 1, also just one of q2 or q3 is selected as 1.\n",
-        "\n",
-        "Here we use “Quantum Entanglement”. Entanglement add filter to the possible answer just limited to the expected value.\n",
-        "\n",
-        "Here is a very simple of entanglement. By using this circuit making the entanglemnt, we get"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "-1q4bT_0zFr-",
-        "colab_type": "code",
-        "outputId": "58a039b5-7198-4862-9021-439fa8d45824",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        }
-      },
-      "source": [
-        "from blueqat import Circuit\n",
-        "Circuit().h[0].cx[0,1].m[:].run(shots=100)"
-      ],
-      "execution_count": 0,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "Counter({'00': 53, '11': 47})"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 3
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "XKLwJpgFzeNn",
-        "colab_type": "text"
-      },
-      "source": [
-        "And applying X gate to the 0th qubit, we get entanglement of 01 and 10 state."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "N9VMjLmpzcSE",
-        "colab_type": "code",
-        "outputId": "02658b0e-40b6-4630-9e05-4223ed43b3ae",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        }
-      },
-      "source": [
-        "from blueqat import Circuit\n",
-        "Circuit().h[0].cx[0,1].x[0].m[:].run(shots=100)"
-      ],
-      "execution_count": 0,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "Counter({'01': 37, '10': 63})"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 4
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "1-42sa9AzimO",
-        "colab_type": "text"
-      },
-      "source": [
-        "By using this state preparation we can set entanglement both on q0,q1 and q2,q3 corresponding to the possible route of car1 and car2.\n",
-        "\n",
-        "This time we have 4qubits and entangled state is,"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "NVZmMV3IzgUk",
-        "colab_type": "code",
-        "outputId": "53787d5a-afea-4fe0-97d1-1b43f215b2f1",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        }
-      },
-      "source": [
-        "from blueqat import Circuit\n",
-        "Circuit().h[0].cx[0,1].x[0].h[2].cx[2,3].x[2].m[:].run(shots=100)"
-      ],
-      "execution_count": 0,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "Counter({'0101': 31, '0110': 19, '1001': 26, '1010': 24})"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 5
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "S4Pyz-DdzqC4",
-        "colab_type": "text"
-      },
-      "source": [
-        "##Swap\n",
-        "Instead of searching the qubit value using sigmaX we use (XX+YY)/2 gate swapping two qubits value.\n",
-        "\n",
-        "By using this gate we can changing the state of 01 and 10, applying to the adiabatic process searching the global minimum on QAOA algorithm.\n",
-        "\n",
-        "##Code\n",
-        "Here is the blueqat code, we are using types of time evolution operator both as classical hamiltonian of Z operator and mixer hamiltonian."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "q0FnoA56znd4",
-        "colab_type": "code",
-        "outputId": "db1b1222-0d56-47bd-d4eb-6b38287df3cc",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 88
-        }
-      },
-      "source": [
-        "import numpy as np\n",
-        "from blueqat import Circuit\n",
-        "from blueqat.pauli import X, Y, Z, I\n",
-        "from blueqat.pauli import qubo_bit as q\n",
-        "from blueqat.vqe import AnsatzBase, Vqe\n",
-        "\n",
-        "def an(index):\n",
-        "    return 0.5 * X[index] + 0.5j * Y[index]\n",
-        "\n",
-        "def cr(index):\n",
-        "    return 0.5 * X[index] - 0.5j * Y[index]\n",
-        "\n",
-        "op1 = (cr(1) * an(0) + cr(0) * an(1)).to_expr().simplify()\n",
-        "op2 = (cr(3) * an(2) + cr(2) * an(3)).to_expr().simplify()\n",
-        "\n",
-        "class QaoaQaoaAnsatz(AnsatzBase):\n",
-        "    def __init__(self, hamiltonian, step=1, init_circuit=None):\n",
-        "        super().__init__(hamiltonian, step * 2)\n",
-        "        self.hamiltonian = hamiltonian.to_expr().simplify()\n",
-        "        if not self.check_hamiltonian():\n",
-        "            raise ValueError(\"Hamiltonian terms are not commutable\")\n",
-        "\n",
-        "        self.step = step\n",
-        "        self.n_qubits = self.hamiltonian.max_n() + 1\n",
-        "        if init_circuit:\n",
-        "            self.init_circuit = init_circuit\n",
-        "            if init_circuit.n_qubits > self.n_qubits:\n",
-        "                self.n_qubits = init_circuit.n_qubits\n",
-        "        else:\n",
-        "            self.init_circuit = Circuit(self.n_qubits).h[:]\n",
-        "        self.init_circuit.make_cache()\n",
-        "        self.time_evolutions = [term.get_time_evolution() for term in self.hamiltonian]\n",
-        "        self.time_evolutions1 = [term.get_time_evolution() for term in op1]\n",
-        "        self.time_evolutions2 = [term.get_time_evolution() for term in op2]\n",
-        "    def check_hamiltonian(self):\n",
-        "        \"\"\"Check hamiltonian is commutable. This condition is required for QaoaAnsatz\"\"\"\n",
-        "        return self.hamiltonian.is_all_terms_commutable()\n",
-        "\n",
-        "    def get_circuit(self, params):\n",
-        "        c = self.init_circuit.copy()\n",
-        "        betas = params[:self.step]\n",
-        "        gammas = params[self.step:]\n",
-        "        for beta, gamma in zip(betas, gammas):\n",
-        "            beta *= np.pi\n",
-        "            gamma *= 2 * np.pi\n",
-        "            for evo in self.time_evolutions:\n",
-        "                evo(c, gamma)\n",
-        "            for evo1 in self.time_evolutions1:\n",
-        "                evo1(c, beta)\n",
-        "            for evo2 in self.time_evolutions2:\n",
-        "                evo2(c, beta)\n",
-        "        return c\n",
-        "\n",
-        "h = 4*q(0)+4*q(1)+4*q(2)+4*q(3)+4*q(0)*q(1)+4*q(0)*q(2)+8*q(1)*q(2)+2*q(1)*q(3)+2*q(2)*q(3)\n",
-        "h = h.to_expr().simplify()\n",
-        "runner = Vqe(QaoaQaoaAnsatz(h,4,Circuit().h[0].cx[0,1].x[0].h[2].cx[2,3].x[2]))\n",
-        "result = runner.run()\n",
-        "\n",
-        "# get probability\n",
-        "print(result.most_common(12))\n",
-        "\n",
-        "print('Result by QAOA')\n",
-        "print(runner.ansatz.get_energy(result.circuit, runner.sampler))"
-      ],
-      "execution_count": 0,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "(((1, 0, 0, 1), 0.9761439764700606), ((0, 1, 0, 1), 0.013733180421308734), ((0, 1, 1, 0), 0.009597498113593592), ((1, 0, 1, 0), 0.0005253449950314455), ((1, 0, 1, 1), 5.616794126873087e-32), ((1, 1, 0, 1), 3.9317124248001565e-32), ((0, 0, 0, 1), 3.9117168874736404e-32), ((0, 1, 1, 1), 1.7988044180444303e-32), ((1, 0, 0, 0), 1.5407439555097884e-32), ((1, 1, 1, 0), 1.3838542217086112e-32), ((0, 0, 1, 0), 9.151450356468662e-33), ((0, 1, 0, 0), 6.995989893749367e-33))\n",
-            "Result by QAOA\n",
-            "8.106347725731453\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Ue0rJrWSz4PZ",
-        "colab_type": "text"
-      },
-      "source": [
-        "Here we get the best solution of (1,0,0,1) with the 98% of possibility. This is the best route removing the traffic jam."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "hmMJTJ40RVHt",
-        "colab_type": "text"
-      },
-      "source": [
-        "##Discussion\n",
-        "By using this, the depth of the circuit will be long, but we don’t have to formulate the constraint term. And the possibility of getting accurate result dramatically increase."
-      ]
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting blueqat\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/f6/73/20f9cff48caee1f69190f2e1ea93c4d7d0a745fc48defb5d3072d8337583/blueqat-0.3.13-py3-none-any.whl (50kB)\n",
+      "\r",
+      "\u001b[K     |██████▌                         | 10kB 21.3MB/s eta 0:00:01\r",
+      "\u001b[K     |█████████████                   | 20kB 1.8MB/s eta 0:00:01\r",
+      "\u001b[K     |███████████████████▍            | 30kB 2.6MB/s eta 0:00:01\r",
+      "\u001b[K     |█████████████████████████▉      | 40kB 1.7MB/s eta 0:00:01\r",
+      "\u001b[K     |████████████████████████████████| 51kB 1.7MB/s \n",
+      "\u001b[?25hRequirement already satisfied: numpy~=1.12 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.17.5)\n",
+      "Requirement already satisfied: scipy>=1.1.0 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.4.1)\n",
+      "Installing collected packages: blueqat\n",
+      "Successfully installed blueqat-0.3.13\n"
+     ]
     }
-  ]
+   ],
+   "source": [
+    "!pip install blueqat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 102
+    },
+    "colab_type": "code",
+    "id": "A8bqofq7ynKG",
+    "outputId": "db644b72-f9db-48a0-fb42-46828d4f34d9"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(((1, 0), 0.49999999999999906), ((0, 1), 0.49999999999999906), ((0, 0), 3.42815530100928e-31), ((1, 1), 3.274080905458301e-33))\n",
+      "Result by QAOA\n",
+      "-2.999999999999995\n",
+      "Result by numpy\n",
+      "-8.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from blueqat import Circuit\n",
+    "from blueqat.pauli import X, Y, Z, I\n",
+    "from blueqat.pauli import qubo_bit as q\n",
+    "from blueqat.vqe import AnsatzBase, Vqe\n",
+    "\n",
+    "def an(index):\n",
+    "    return 0.5 * X[index] + 0.5j * Y[index]\n",
+    "\n",
+    "def cr(index):\n",
+    "    return 0.5 * X[index] - 0.5j * Y[index]\n",
+    "\n",
+    "op = (cr(1) * an(0) + cr(0) * an(1)).to_expr().simplify()\n",
+    "\n",
+    "class QaoaQaoaAnsatz(AnsatzBase):\n",
+    "    def __init__(self, hamiltonian, step=1, init_circuit=None):\n",
+    "        super().__init__(hamiltonian, step * 2)\n",
+    "        self.hamiltonian = hamiltonian.to_expr().simplify()\n",
+    "        if not self.check_hamiltonian():\n",
+    "            raise ValueError(\"Hamiltonian terms are not commutable\")\n",
+    "\n",
+    "        self.step = step\n",
+    "        self.n_qubits = self.hamiltonian.max_n() + 1\n",
+    "        if init_circuit:\n",
+    "            self.init_circuit = init_circuit\n",
+    "            if init_circuit.n_qubits > self.n_qubits:\n",
+    "                self.n_qubits = init_circuit.n_qubits\n",
+    "        else:\n",
+    "            self.init_circuit = Circuit(self.n_qubits).h[:]\n",
+    "        self.init_circuit.make_cache()\n",
+    "        self.time_evolutions = [term.get_time_evolution() for term in self.hamiltonian]\n",
+    "        self.time_evolutions2 = [term.get_time_evolution() for term in op]\n",
+    "    def check_hamiltonian(self):\n",
+    "        \"\"\"Check hamiltonian is commutable. This condition is required for QaoaAnsatz\"\"\"\n",
+    "        return self.hamiltonian.is_all_terms_commutable()\n",
+    "\n",
+    "    def get_circuit(self, params):\n",
+    "        c = self.init_circuit.copy()\n",
+    "        betas = params[:self.step]\n",
+    "        gammas = params[self.step:]\n",
+    "        for beta, gamma in zip(betas, gammas):\n",
+    "            beta *= np.pi\n",
+    "            gamma *= 2 * np.pi\n",
+    "            for evo in self.time_evolutions:\n",
+    "                evo(c, gamma)\n",
+    "            for evo2 in self.time_evolutions2:\n",
+    "                evo2(c, beta)\n",
+    "        return c\n",
+    "\n",
+    "h = -3*q(0)-3*q(1)-2*q(0)*q(1)\n",
+    "h = h.to_expr().simplify()\n",
+    "runner = Vqe(QaoaQaoaAnsatz(h,4,Circuit().h[0].cx[0,1].x[0]))\n",
+    "result = runner.run()\n",
+    "\n",
+    "# get probability\n",
+    "print(result.most_common(12))\n",
+    "\n",
+    "print('Result by QAOA')\n",
+    "print(runner.ansatz.get_energy_sparse(result.circuit))\n",
+    "\n",
+    "# Hamiltonian to matrix\n",
+    "mat = h.to_matrix()\n",
+    "\n",
+    "# Calculate by numpy\n",
+    "print('Result by numpy')\n",
+    "print(np.linalg.eigh(mat)[0][0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Pvz6c0zKzO43"
+   },
+   "source": [
+    "Numpy shows the minimum result as -8 but this QAOA has limitation of |01> or |10> as a result using entanglement and XYmixer. |00> or |11> doesn't appear in the result.\n",
+    "\n",
+    "Using this we can get much more accurate result on a specific problem with constraints.\n",
+    "\n",
+    "<img width=\"1281\" alt=\"スクリーンショット 2020-02-25 0.39.32.png\" src=\"https://qiita-image-store.s3.ap-northeast-1.amazonaws.com/0/218694/85efc267-c34d-dbc8-1bb0-25bc22cfb1c0.png\">"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "A9M2QO-Fzaa6"
+   },
+   "source": [
+    "##Traffic flow optimization without constraint term on quantum computing using quantum alternating operator ansatz\n",
+    "Here we adopted traffic flow optimization problem as a case study, but this technique is a general one and can be applied to a variety of problems.\n",
+    "\n",
+    "References\n",
+    "As a model we use traffic flow modeling from VW paper.\n",
+    "\n",
+    "Traffic flow optimization using a quantum annealer  \n",
+    "Florian Neukart, Gabriele Compostella, Christian Seidel, David von Dollen, Sheir Yarkoni, Bob Parney  \n",
+    "(Submitted on 4 Aug 2017 (v1), last revised 9 Aug 2017 (this version, v2))  \n",
+    "https://arxiv.org/pdf/1708.01625.pdf\n",
+    "\n",
+    "As an algorithm we use QAOA for universal gate model.  \n",
+    "A Quantum Approximate Optimization Algorithm  \n",
+    "Edward Farhi, Jeffrey Goldstone, Sam Gutmann  \n",
+    "https://arxiv.org/abs/1411.4028  \n",
+    "\n",
+    "And technique to use XY mixer.  \n",
+    "From the Quantum Approximate Optimization Algorithm to a Quantum Alternating   Operator Ansatz\n",
+    "Stuart Hadfield, Zhihui Wang, Bryan O’Gorman, Eleanor G. Rieffel, Davide Venturelli, Rupak Biswas  \n",
+    "https://arxiv.org/abs/1709.03489  \n",
+    "\n",
+    "And prepare an entangled state.  \n",
+    "Portfolio rebalancing experiments using the\n",
+    "Quantum Alternating Operator Ansatz  \n",
+    "Mark Hodson∗, Brendan Ruck∗, Hugh (Hui Chuan) Ong†, David Garvin∗, Stefan Dulman†\n",
+    "∗Rigetti Computing\n",
+    "†Commonwealth Bank of Australia  \n",
+    "https://arxiv.org/pdf/1911.05296.pdf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "ilMGpQ2kQOjq"
+   },
+   "source": [
+    "##Modeling and formulation\n",
+    "We use the model from the VW. We prepare start point A and goal point B. And named each street from s0 to s11.\n",
+    "\n",
+    "<img src=\"https://miro.medium.com/max/730/0*jdvbeWCvUMG-UKis\">\n",
+    "\n",
+    "Let’s prepare two cars and set possible route setting for each vehicles.\n",
+    "\n",
+    "car1  \n",
+    "route1-1(q0)：s0,s3,s6,s9  \n",
+    "route1–2 (q1)：s0,s3,s8,s11  \n",
+    "\n",
+    "car2  \n",
+    "route2–1(q2):s0,s3,s8,s11  \n",
+    "route2–2(q3):s2,s7,s10,s11\n",
+    "\n",
+    "q0 to q3 denote qubits. If the route selected the value of qubit is 1 else 0. If route1–1 is selected for car1 and route2–2 is selected for car2 the answer is, (1,0,0,1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "_vb17KENQpaD"
+   },
+   "source": [
+    "Cost=(q0+q1+q2)²+(q0+q1+q2)²+q0²+q0²+(q1+q2)²+(q1+q2+q3)²+q3²+q3²+q3²=4q0+4q1+4q2+4q3+4q0q1+4q0q2+8q1q2+2q1q3+2q2q3\n",
+    "\n",
+    "And the constraint is that car1 select just 1route from q0 and q1. Car2 also select just one route from q2 and q3.\n",
+    "\n",
+    "Const=(q0+q1−1)²+(q2+q3−1)²=q0−q1−q2−q3+2q0q1+2q2q3+2\n",
+    "\n",
+    "Usually we connect these equation using variable K.\n",
+    "\n",
+    "Cost+K∗ConstCost+K∗Const\n",
+    "\n",
+    "Now we think about a new technique to remote this Const term."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "hsK9MfhHQ0w7"
+   },
+   "source": [
+    "##Prepare the initial state\n",
+    "Usually quantum annealing is searching the value almost randomly using sigmaX. And the initial state is |+> as the eigen state of hamiltonian X. As the mixer it is using time evolution of hamitonian X.\n",
+    "\n",
+    "But here we think about the pattern of searching. Each car always select just one route from the possible routes. So, just one of q0 or q1 is selected as 1, also just one of q2 or q3 is selected as 1.\n",
+    "\n",
+    "Here we use “Quantum Entanglement”. Entanglement add filter to the possible answer just limited to the expected value.\n",
+    "\n",
+    "Here is a very simple of entanglement. By using this circuit making the entanglemnt, we get"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "colab_type": "code",
+    "id": "-1q4bT_0zFr-",
+    "outputId": "58a039b5-7198-4862-9021-439fa8d45824"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Counter({'00': 46, '11': 54})"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from blueqat import Circuit\n",
+    "Circuit().h[0].cx[0,1].m[:].run(shots=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "XKLwJpgFzeNn"
+   },
+   "source": [
+    "And applying X gate to the 0th qubit, we get entanglement of 01 and 10 state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "colab_type": "code",
+    "id": "N9VMjLmpzcSE",
+    "outputId": "02658b0e-40b6-4630-9e05-4223ed43b3ae"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Counter({'01': 39, '10': 61})"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from blueqat import Circuit\n",
+    "Circuit().h[0].cx[0,1].x[0].m[:].run(shots=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "1-42sa9AzimO"
+   },
+   "source": [
+    "By using this state preparation we can set entanglement both on q0,q1 and q2,q3 corresponding to the possible route of car1 and car2.\n",
+    "\n",
+    "This time we have 4qubits and entangled state is,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "colab_type": "code",
+    "id": "NVZmMV3IzgUk",
+    "outputId": "53787d5a-afea-4fe0-97d1-1b43f215b2f1"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Counter({'0110': 25, '0101': 22, '1001': 22, '1010': 31})"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from blueqat import Circuit\n",
+    "Circuit().h[0].cx[0,1].x[0].h[2].cx[2,3].x[2].m[:].run(shots=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "S4Pyz-DdzqC4"
+   },
+   "source": [
+    "##Swap\n",
+    "Instead of searching the qubit value using sigmaX we use (XX+YY)/2 gate swapping two qubits value.\n",
+    "\n",
+    "By using this gate we can changing the state of 01 and 10, applying to the adiabatic process searching the global minimum on QAOA algorithm.\n",
+    "\n",
+    "##Code\n",
+    "Here is the blueqat code, we are using types of time evolution operator both as classical hamiltonian of Z operator and mixer hamiltonian."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 88
+    },
+    "colab_type": "code",
+    "id": "q0FnoA56znd4",
+    "outputId": "db1b1222-0d56-47bd-d4eb-6b38287df3cc"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(((1, 0, 0, 1), 0.9725719073393897), ((0, 1, 0, 1), 0.024015993375551083), ((1, 0, 1, 0), 0.002505733361743824), ((0, 1, 1, 0), 0.0009063659233088916), ((1, 0, 0, 0), 3.5709449507923647e-31), ((1, 1, 0, 1), 1.9528948916201288e-31), ((0, 0, 0, 1), 1.0405633442510895e-31), ((1, 0, 1, 1), 4.5019364766436164e-32), ((0, 1, 1, 1), 1.9322494020172565e-32), ((0, 1, 0, 0), 1.9259299443872359e-32), ((1, 1, 1, 0), 1.898225421321941e-32), ((0, 0, 1, 0), 9.408022689142076e-33))\n",
+      "Result by QAOA\n",
+      "8.065305847584497\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from blueqat import Circuit\n",
+    "from blueqat.pauli import X, Y, Z, I\n",
+    "from blueqat.pauli import qubo_bit as q\n",
+    "from blueqat.vqe import AnsatzBase, Vqe\n",
+    "\n",
+    "def an(index):\n",
+    "    return 0.5 * X[index] + 0.5j * Y[index]\n",
+    "\n",
+    "def cr(index):\n",
+    "    return 0.5 * X[index] - 0.5j * Y[index]\n",
+    "\n",
+    "op1 = (cr(1) * an(0) + cr(0) * an(1)).to_expr().simplify()\n",
+    "op2 = (cr(3) * an(2) + cr(2) * an(3)).to_expr().simplify()\n",
+    "\n",
+    "class QaoaQaoaAnsatz(AnsatzBase):\n",
+    "    def __init__(self, hamiltonian, step=1, init_circuit=None):\n",
+    "        super().__init__(hamiltonian, step * 2)\n",
+    "        self.hamiltonian = hamiltonian.to_expr().simplify()\n",
+    "        if not self.check_hamiltonian():\n",
+    "            raise ValueError(\"Hamiltonian terms are not commutable\")\n",
+    "\n",
+    "        self.step = step\n",
+    "        self.n_qubits = self.hamiltonian.max_n() + 1\n",
+    "        if init_circuit:\n",
+    "            self.init_circuit = init_circuit\n",
+    "            if init_circuit.n_qubits > self.n_qubits:\n",
+    "                self.n_qubits = init_circuit.n_qubits\n",
+    "        else:\n",
+    "            self.init_circuit = Circuit(self.n_qubits).h[:]\n",
+    "        self.init_circuit.make_cache()\n",
+    "        self.time_evolutions = [term.get_time_evolution() for term in self.hamiltonian]\n",
+    "        self.time_evolutions1 = [term.get_time_evolution() for term in op1]\n",
+    "        self.time_evolutions2 = [term.get_time_evolution() for term in op2]\n",
+    "    def check_hamiltonian(self):\n",
+    "        \"\"\"Check hamiltonian is commutable. This condition is required for QaoaAnsatz\"\"\"\n",
+    "        return self.hamiltonian.is_all_terms_commutable()\n",
+    "\n",
+    "    def get_circuit(self, params):\n",
+    "        c = self.init_circuit.copy()\n",
+    "        betas = params[:self.step]\n",
+    "        gammas = params[self.step:]\n",
+    "        for beta, gamma in zip(betas, gammas):\n",
+    "            beta *= np.pi\n",
+    "            gamma *= 2 * np.pi\n",
+    "            for evo in self.time_evolutions:\n",
+    "                evo(c, gamma)\n",
+    "            for evo1 in self.time_evolutions1:\n",
+    "                evo1(c, beta)\n",
+    "            for evo2 in self.time_evolutions2:\n",
+    "                evo2(c, beta)\n",
+    "        return c\n",
+    "\n",
+    "h = 4*q(0)+4*q(1)+4*q(2)+4*q(3)+4*q(0)*q(1)+4*q(0)*q(2)+8*q(1)*q(2)+2*q(1)*q(3)+2*q(2)*q(3)\n",
+    "h = h.to_expr().simplify()\n",
+    "runner = Vqe(QaoaQaoaAnsatz(h,4,Circuit().h[0].cx[0,1].x[0].h[2].cx[2,3].x[2]))\n",
+    "result = runner.run()\n",
+    "\n",
+    "# get probability\n",
+    "print(result.most_common(12))\n",
+    "\n",
+    "print('Result by QAOA')\n",
+    "print(runner.ansatz.get_energy_sparse(result.circuit))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Ue0rJrWSz4PZ"
+   },
+   "source": [
+    "Here we get the best solution of (1,0,0,1) with the 98% of possibility. This is the best route removing the traffic jam."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "hmMJTJ40RVHt"
+   },
+   "source": [
+    "##Discussion\n",
+    "By using this, the depth of the circuit will be long, but we don’t have to formulate the constraint term. And the possibility of getting accurate result dramatically increase."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "106_vqe_qaoa06.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/tutorial/200_vqe_en.ipynb
+++ b/tutorial/200_vqe_en.ipynb
@@ -89,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -99,7 +99,7 @@
        "       [-4.56+2.45j, -1.11+0.j  ]])"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -241,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -249,7 +249,7 @@
      "output_type": "stream",
      "text": [
       "Result by VQE\n",
-      "-4.43253725010219\n",
+      "-4.4478075472540315\n",
       "Result by numpy\n",
       "-4.450818602983201\n"
      ]
@@ -277,7 +277,7 @@
     "result = runner.run()\n",
     "\n",
     "print('Result by VQE')\n",
-    "print(runner.ansatz.get_energy(result.circuit, runner.sampler))\n",
+    "print(runner.ansatz.get_energy_sparse(result.circuit))\n",
     "\n",
     "# This is for check\n",
     "mat = h.to_matrix()\n",
@@ -295,9 +295,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "conda_python3",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda_python3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -309,7 +309,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/tutorial/300_cop_en.ipynb
+++ b/tutorial/300_cop_en.ipynb
@@ -1,422 +1,440 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "103_vqe_qaoa03.ipynb",
-      "provenance": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Z57Y5-H3uuOV"
+   },
+   "source": [
+    "#Combinatorial Optimization Problems on Variational Quantum Eigensolver(VQE) and QAOA"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Z57Y5-H3uuOV",
-        "colab_type": "text"
-      },
-      "source": [
-        "#Combinatorial Optimization Problems on Variational Quantum Eigensolver(VQE) and QAOA"
-      ]
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "23QCMzt_u3KT"
+   },
+   "source": [
+    "Combinatorial optimization problem is one of the usage of variational algorithm. Who want to start learning quantum-classical hybrid algorithm on quantum computing, it may be a good subject to strat.\n",
+    "\n",
+    "Combinatorial optimization problem is a problem to find the best solution by solving a minimized optimization problem. If you want to solve a social problem, to formulate this into a combination of binary number 0 and 1 and give some constraint on it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "9Jbvpe9mu6qB"
+   },
+   "source": [
+    "##Formulation of combinatorial optimization problem and VQE\n",
+    "The formulation think the hamiltonian as a cost function for social problems and try to find the best answer from the qubits. The main step is,\n",
+    "\n",
+    "1. Use ising model which is a basic physics model\n",
+    "2. Use combination of Z as a hamiltonian\n",
+    "3. More practically we use QUBO for the formulation which is 0 and 1 instead of -1 and +1 of ising model\n",
+    "\n",
+    "Usually we rarely use VQE without qaoa ansatz for the combinatorial optimization problem, but this time we just set a simple 1qubit problem.\n",
+    "\n",
+    "```python\n",
+    "h = -Z(0) - Z(0)*Z(1)\n",
+    "```\n",
+    "\n",
+    "The number after Z is the number of qubits. Here we are using 0th qubit and 1st qubit in the quantum circuit. and the coefficients in front of Z is important.\n",
+    "\n",
+    "The coefficient of Z(0) is a bias.\n",
+    "The coefficient of Z(0)*Z(1) is a weight.\n",
+    "\n",
+    "Now we have both value of -1 as each coefficient.\n",
+    "\n",
+    "Z takes -1 or +1 as a expectation value. If the hamiltonian h takes smaller value it will be the answer. \n",
+    "\n",
+    "Here we just check the whole answer in the table.\n",
+    "\n",
+    "Z(0) | Z(1) | h\n",
+    "--:|:----:|:--\n",
+    "-1|-1|0\n",
+    "-1|1|2\n",
+    "1|-1|0\n",
+    "1|1|-2\n",
+    "\n",
+    "The hamiltonian takes the minimu value of -2 when Z(0)=1 and Z(1)=1. VQE solve this automatically. This time as an ansatz we used 4 parameters of a,b,c,d. a, b for the 0th qubit, and c, d for the 1st qubit.\n",
+    "\n",
+    "Now we check it on blueqat, first we need to install blueqat and give this code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 136
     },
+    "colab_type": "code",
+    "id": "opzc-Mvfu_gd",
+    "outputId": "79113e2c-7380-470a-e7b0-d7a06f95da3d"
+   },
+   "outputs": [
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "23QCMzt_u3KT",
-        "colab_type": "text"
-      },
-      "source": [
-        "Combinatorial optimization problem is one of the usage of variational algorithm. Who want to start learning quantum-classical hybrid algorithm on quantum computing, it may be a good subject to strat.\n",
-        "\n",
-        "Combinatorial optimization problem is a problem to find the best solution by solving a minimized optimization problem. If you want to solve a social problem, to formulate this into a combination of binary number 0 and 1 and give some constraint on it."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "9Jbvpe9mu6qB",
-        "colab_type": "text"
-      },
-      "source": [
-        "##Formulation of combinatorial optimization problem and VQE\n",
-        "The formulation think the hamiltonian as a cost function for social problems and try to find the best answer from the qubits. The main step is,\n",
-        "\n",
-        "1. Use ising model which is a basic physics model\n",
-        "2. Use combination of Z as a hamiltonian\n",
-        "3. More practically we use QUBO for the formulation which is 0 and 1 instead of -1 and +1 of ising model\n",
-        "\n",
-        "Usually we rarely use VQE without qaoa ansatz for the combinatorial optimization problem, but this time we just set a simple 1qubit problem.\n",
-        "\n",
-        "```python\n",
-        "h = -Z(0) - Z(0)*Z(1)\n",
-        "```\n",
-        "\n",
-        "The number after Z is the number of qubits. Here we are using 0th qubit and 1st qubit in the quantum circuit. and the coefficients in front of Z is important.\n",
-        "\n",
-        "The coefficient of Z(0) is a bias.\n",
-        "The coefficient of Z(0)*Z(1) is a weight.\n",
-        "\n",
-        "Now we have both value of -1 as each coefficient.\n",
-        "\n",
-        "Z takes -1 or +1 as a expectation value. If the hamiltonian h takes smaller value it will be the answer. \n",
-        "\n",
-        "Here we just check the whole answer in the table.\n",
-        "\n",
-        "Z(0) | Z(1) | h\n",
-        "--:|:----:|:--\n",
-        "-1|-1|0\n",
-        "-1|1|2\n",
-        "1|-1|0\n",
-        "1|1|-2\n",
-        "\n",
-        "The hamiltonian takes the minimu value of -2 when Z(0)=1 and Z(1)=1. VQE solve this automatically. This time as an ansatz we used 4 parameters of a,b,c,d. a, b for the 0th qubit, and c, d for the 1st qubit.\n",
-        "\n",
-        "Now we check it on blueqat, first we need to install blueqat and give this code."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "opzc-Mvfu_gd",
-        "colab_type": "code",
-        "outputId": "79113e2c-7380-470a-e7b0-d7a06f95da3d",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 136
-        }
-      },
-      "source": [
-        "!pip3 install blueqat"
-      ],
-      "execution_count": 0,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Collecting blueqat\n",
-            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/f6/73/20f9cff48caee1f69190f2e1ea93c4d7d0a745fc48defb5d3072d8337583/blueqat-0.3.13-py3-none-any.whl (50kB)\n",
-            "\r\u001b[K     |██████▌                         | 10kB 16.4MB/s eta 0:00:01\r\u001b[K     |█████████████                   | 20kB 1.8MB/s eta 0:00:01\r\u001b[K     |███████████████████▍            | 30kB 2.3MB/s eta 0:00:01\r\u001b[K     |█████████████████████████▉      | 40kB 1.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████████████| 51kB 1.6MB/s \n",
-            "\u001b[?25hRequirement already satisfied: numpy~=1.12 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.17.5)\n",
-            "Requirement already satisfied: scipy>=1.1.0 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.4.1)\n",
-            "Installing collected packages: blueqat\n",
-            "Successfully installed blueqat-0.3.13\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "qIc5WG5dumej",
-        "colab_type": "code",
-        "outputId": "69061199-2601-4f8d-ca3a-afcc65a354e6",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 51
-        }
-      },
-      "source": [
-        "import numpy as np\n",
-        "from blueqat import Circuit\n",
-        "from blueqat.pauli import X, Y, Z, I\n",
-        "from blueqat.vqe import AnsatzBase, Vqe\n",
-        "\n",
-        "class OneQubitAnsatz(AnsatzBase):\n",
-        "    def __init__(self, hamiltonian):\n",
-        "        super().__init__(hamiltonian.to_expr(), 4)\n",
-        "        self.step = 1\n",
-        "\n",
-        "    def get_circuit(self, params):\n",
-        "        a, b, c, d = params\n",
-        "        return Circuit().ry(a)[0].rz(b)[0].ry(c)[1].rz(d)[1]\n",
-        "\n",
-        "\n",
-        "# hamiltonian is important\n",
-        "h = -Z(0) - Z(0)*Z(1)\n",
-        "runner = Vqe(OneQubitAnsatz(h))\n",
-        "result = runner.run()\n",
-        "\n",
-        "print('Result by VQE')\n",
-        "print(runner.ansatz.get_energy(result.circuit, runner.sampler))"
-      ],
-      "execution_count": 0,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Result by VQE\n",
-            "-1.99999508430852\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "6xNoXOE4vHUZ",
-        "colab_type": "text"
-      },
-      "source": [
-        "Now we get -2 as the expectation value of minimum value.\n",
-        "\n",
-        "For practical use we usually solve much bigger problems. Now we can see this problem as a kind of classification problem which bias of Z(0) shows that Alice belongs to the group1 and weight of Z(0)*Z(1) shows that Alice and Bob belong to the same group as a kind of max-cut problem.\n",
-        "\n",
-        "Here we used Z for operator, now we use a technique to transform it into 01 binary number.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "3DOTeXadvJzG",
-        "colab_type": "text"
-      },
-      "source": [
-        "##Formulation with QUBO\n",
-        "If use Z in the hamiltoinan Z takes -1 or +1 as an expectaion value. But it is little bit uncomfortable for the social problems. Usually we use 01 binary number so, we just transform hamiltonian into binary number using,\n",
-        "\n",
-        "$$\n",
-        "q = \\frac{Z + 1}{2}\n",
-        "$$\n",
-        "\n",
-        "This is the transform of -1 to 0 and we now can use QUBO as a formulation."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cvKkwYayvOga",
-        "colab_type": "text"
-      },
-      "source": [
-        "##QUBO programming\n",
-        "Let's use qubo on blueqat. Blueqat has a function for qubo. Now we can write the qubo form as,\n",
-        "\n",
-        "```python\n",
-        "h = -3*q(0)-3*q(1)-2*q(0)*q(1)\n",
-        "```\n",
-        "\n",
-        "This hamiltonian obviously takes the minimum value of -8 when q(0)=1 and q(1)=1. By solving on VQE we may get the similar result."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "rkYdYTbWu-F4",
-        "colab_type": "code",
-        "outputId": "b3644963-3ce1-4900-e7a9-a60c44a3cb55",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 85
-        }
-      },
-      "source": [
-        "import numpy as np\n",
-        "from blueqat import Circuit\n",
-        "from blueqat.pauli import X, Y, Z, I\n",
-        "from blueqat.pauli import qubo_bit as q\n",
-        "from blueqat.vqe import AnsatzBase, Vqe\n",
-        "\n",
-        "class QubitAnsatz(AnsatzBase):\n",
-        "    def __init__(self, hamiltonian):\n",
-        "        super().__init__(hamiltonian, 4)\n",
-        "        self.step = 1\n",
-        "\n",
-        "    def get_circuit(self, params):\n",
-        "        a, b, c, d = params\n",
-        "        return Circuit().ry(a)[0].rz(b)[0].ry(c)[1].rz(d)[1]\n",
-        "\n",
-        "h = -3*q(0)-3*q(1)-2*q(0)*q(1)\n",
-        "h = h.to_expr().simplify()\n",
-        "runner = Vqe(QubitAnsatz(h))\n",
-        "result = runner.run()\n",
-        "\n",
-        "print('Result by VQE')\n",
-        "print(runner.ansatz.get_energy(result.circuit, runner.sampler))\n",
-        "\n",
-        "# Hamiltonian to matrix\n",
-        "mat = h.to_matrix()\n",
-        "\n",
-        "# Calculate by numpy\n",
-        "print('Result by numpy')\n",
-        "print(np.linalg.eigh(mat)[0][0])"
-      ],
-      "execution_count": 0,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Result by VQE\n",
-            "-7.986060449670348\n",
-            "Result by numpy\n",
-            "-8.0\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "DYsNMr6QvUnh",
-        "colab_type": "text"
-      },
-      "source": [
-        "We correctly the result. This time we just used 2qubits. But actually it is very difficult to get the right answer on bigger number of qubits. To compute much more efficiently we are using a new ansatz called QAOA ansatz for combinatorial optimization problem."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "etA_TEnsvWzL",
-        "colab_type": "text"
-      },
-      "source": [
-        "##QAOA\n",
-        "QAOA has a special form of ansatz especially to solve combinatorial optimization problem using the similar step of VQE. Now we try to use QAOA(Quantum Approximate Opitmization Alogirthm) in this chapter."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "9e4vdEK9vZq8",
-        "colab_type": "text"
-      },
-      "source": [
-        "##2-5-1 Quantum Adiabatic Algorithm\n",
-        "QAA is an algorithm to change the state vector adiabatically to keep the ground state of the hamiltonian through the time evolution.\n",
-        "\n",
-        "We set the initial hamiltonian as $H_{start}$ and the final Hamiltonian as $H_{fin}$. t is time and T is the whole step of schedule.\n",
-        "\n",
-        "$$\n",
-        "H_{temp} = (1-\\frac{t}{T})H_{start} + \\frac{t}{T}H_{fin}\n",
-        "$$\n",
-        "\n",
-        "The hamiltoinan adiabatically changed according to the time t and the eigenstate of state vector keep the ground state if T is enough big.\n",
-        "\n",
-        "$$\n",
-        "H_{temp}\\mid \\psi \\rangle = E_{0temp}\\mid \\psi \\rangle\n",
-        "$$\n",
-        "\n",
-        "Time evolution is,\n",
-        "\n",
-        "$$\n",
-        "\\mid \\psi_{t+1} \\rangle = U \\mid \\psi_t \\rangle = e^{-iHt}  \\mid \\psi_t \\rangle\n",
-        "$$\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "FA9B9idIvgTH",
-        "colab_type": "text"
-      },
-      "source": [
-        "##QAOA\n",
-        "QAOA is basically using the idea of adiabatic process and transform it into a variational algorithm as ansatz of hamiltonian.\n",
-        "\n",
-        "![https___qiita-user-contents.imgix.net_https%3A%2F%2Fqiita-image-store.s3.ap-northeast-1.amazonaws.com%2F0%2F218694%2Fe10f1843-cc16-cdfe-e4a6-e2fbaab6df9f.png_ixlib=rb-1.2.png](https://qiita-image-store.s3.ap-northeast-1.amazonaws.com/0/218694/812819f5-0037-5a30-2690-8ed39c0b1a06.png)\n",
-        "https://app.quantumcomputing.com/\n",
-        "\n",
-        "The first H on the circuit shows the initial eigen state of hamiltonian X. CX-Rz-CX shows the weight of hamiltonian and Rz shows the bias of the hamiltonian. Rx is a time evolution of initial hamiltonian X.\n",
-        "\n",
-        "Let's just see the inside of QaoaAnsatz of blueqat. Hamiltonian consists of Z operator and automatically make a variational transformation of time evolution ansatz.\n",
-        "\n",
-        "\n",
-        "```python\n",
-        "class QaoaAnsatz(AnsatzBase):\n",
-        "    def __init__(self, hamiltonian, step=1, init_circuit=None):\n",
-        "        super().__init__(hamiltonian, step * 2)\n",
-        "        self.hamiltonian = hamiltonian.to_expr().simplify()\n",
-        "        if not self.check_hamiltonian():\n",
-        "            raise ValueError(\"Hamiltonian terms are not commutable\")\n",
-        "\n",
-        "        self.step = step\n",
-        "        self.n_qubits = self.hamiltonian.max_n() + 1\n",
-        "        if init_circuit:\n",
-        "            self.init_circuit = init_circuit\n",
-        "            if init_circuit.n_qubits > self.n_qubits:\n",
-        "                self.n_qubits = init_circuit.n_qubits\n",
-        "        else:\n",
-        "            self.init_circuit = Circuit(self.n_qubits).h[:]\n",
-        "        self.init_circuit.make_cache()\n",
-        "        self.time_evolutions = [term.get_time_evolution() for term in self.hamiltonian]\n",
-        "\n",
-        "    def check_hamiltonian(self):\n",
-        "        \"\"\"Check hamiltonian is commutable. This condition is required for QaoaAnsatz\"\"\"\n",
-        "        return self.hamiltonian.is_all_terms_commutable()\n",
-        "\n",
-        "    def get_circuit(self, params):\n",
-        "        c = self.init_circuit.copy()\n",
-        "        betas = params[:self.step]\n",
-        "        gammas = params[self.step:]\n",
-        "        for beta, gamma in zip(betas, gammas):\n",
-        "            beta *= np.pi\n",
-        "            gamma *= 2 * np.pi\n",
-        "            for evo in self.time_evolutions:\n",
-        "                evo(c, gamma)\n",
-        "            c.rx(beta)[:]\n",
-        "        return c\n",
-        "```\n",
-        "\n",
-        "On actual use, the library automatically do the calculation and you don't to implement a complicated formulation or time evolution.\n",
-        "\n",
-        "Blueqat do most of the process and what you just need to do is to formulate the hamiltonian as a combinatorial optimization with binary number of 0 and 1.\n",
-        "\n",
-        "Now we see an example of simple problem on qubo.\n",
-        "\n",
-        "```python\n",
-        "cost = -3*q(0)-3*q(1)-2*q(0)*q(1)\n",
-        "```\n",
-        "\n",
-        "This take obviously -8 as a result. It is very easy, now we can think about the social problem as binary number. q(0) and q(1) has -3 of bias and q(0)*q(1) has -2 as a weight.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "mcfRj-T-vSfz",
-        "colab_type": "code",
-        "outputId": "73f0d2c4-2d2a-4fd2-f6b5-21822297b472",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        }
-      },
-      "source": [
-        "from blueqat import vqe\n",
-        "from blueqat.pauli import qubo_bit as q\n",
-        "\n",
-        "h = -3*q(0)-3*q(1)-2*q(0)*q(1)\n",
-        "step = 2\n",
-        "\n",
-        "result = vqe.Vqe(vqe.QaoaAnsatz(h, step)).run()\n",
-        "print(result.most_common(12))"
-      ],
-      "execution_count": 0,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "(((1, 1), 0.9552579305295982), ((0, 0), 0.02975250342490814), ((0, 1), 0.0074947830227465335), ((1, 0), 0.007494783022746532))\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "pgvdZYqGvtHP",
-        "colab_type": "text"
-      },
-      "source": [
-        "We get combination of (1,1) as the probability of 96%."
-      ]
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting blueqat\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/f6/73/20f9cff48caee1f69190f2e1ea93c4d7d0a745fc48defb5d3072d8337583/blueqat-0.3.13-py3-none-any.whl (50kB)\n",
+      "\r",
+      "\u001b[K     |██████▌                         | 10kB 16.4MB/s eta 0:00:01\r",
+      "\u001b[K     |█████████████                   | 20kB 1.8MB/s eta 0:00:01\r",
+      "\u001b[K     |███████████████████▍            | 30kB 2.3MB/s eta 0:00:01\r",
+      "\u001b[K     |█████████████████████████▉      | 40kB 1.7MB/s eta 0:00:01\r",
+      "\u001b[K     |████████████████████████████████| 51kB 1.6MB/s \n",
+      "\u001b[?25hRequirement already satisfied: numpy~=1.12 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.17.5)\n",
+      "Requirement already satisfied: scipy>=1.1.0 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.4.1)\n",
+      "Installing collected packages: blueqat\n",
+      "Successfully installed blueqat-0.3.13\n"
+     ]
     }
-  ]
+   ],
+   "source": [
+    "!pip3 install blueqat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 51
+    },
+    "colab_type": "code",
+    "id": "qIc5WG5dumej",
+    "outputId": "69061199-2601-4f8d-ca3a-afcc65a354e6"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Result by VQE\n",
+      "-1.9999929521736683\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from blueqat import Circuit\n",
+    "from blueqat.pauli import X, Y, Z, I\n",
+    "from blueqat.vqe import AnsatzBase, Vqe\n",
+    "\n",
+    "class OneQubitAnsatz(AnsatzBase):\n",
+    "    def __init__(self, hamiltonian):\n",
+    "        super().__init__(hamiltonian.to_expr(), 4)\n",
+    "        self.step = 1\n",
+    "\n",
+    "    def get_circuit(self, params):\n",
+    "        a, b, c, d = params\n",
+    "        return Circuit().ry(a)[0].rz(b)[0].ry(c)[1].rz(d)[1]\n",
+    "\n",
+    "\n",
+    "# hamiltonian is important\n",
+    "h = -Z(0) - Z(0)*Z(1)\n",
+    "runner = Vqe(OneQubitAnsatz(h))\n",
+    "result = runner.run()\n",
+    "\n",
+    "print('Result by VQE')\n",
+    "print(runner.ansatz.get_energy_sparse(result.circuit))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "6xNoXOE4vHUZ"
+   },
+   "source": [
+    "Now we get -2 as the expectation value of minimum value.\n",
+    "\n",
+    "For practical use we usually solve much bigger problems. Now we can see this problem as a kind of classification problem which bias of Z(0) shows that Alice belongs to the group1 and weight of Z(0)*Z(1) shows that Alice and Bob belong to the same group as a kind of max-cut problem.\n",
+    "\n",
+    "Here we used Z for operator, now we use a technique to transform it into 01 binary number.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "3DOTeXadvJzG"
+   },
+   "source": [
+    "##Formulation with QUBO\n",
+    "If use Z in the hamiltoinan Z takes -1 or +1 as an expectaion value. But it is little bit uncomfortable for the social problems. Usually we use 01 binary number so, we just transform hamiltonian into binary number using,\n",
+    "\n",
+    "$$\n",
+    "q = \\frac{Z + 1}{2}\n",
+    "$$\n",
+    "\n",
+    "This is the transform of -1 to 0 and we now can use QUBO as a formulation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "cvKkwYayvOga"
+   },
+   "source": [
+    "##QUBO programming\n",
+    "Let's use qubo on blueqat. Blueqat has a function for qubo. Now we can write the qubo form as,\n",
+    "\n",
+    "```python\n",
+    "h = -3*q(0)-3*q(1)-2*q(0)*q(1)\n",
+    "```\n",
+    "\n",
+    "This hamiltonian obviously takes the minimum value of -8 when q(0)=1 and q(1)=1. By solving on VQE we may get the similar result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 85
+    },
+    "colab_type": "code",
+    "id": "rkYdYTbWu-F4",
+    "outputId": "b3644963-3ce1-4900-e7a9-a60c44a3cb55"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Result by VQE\n",
+      "-7.917904376487771\n",
+      "Result by numpy\n",
+      "-8.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from blueqat import Circuit\n",
+    "from blueqat.pauli import X, Y, Z, I\n",
+    "from blueqat.pauli import qubo_bit as q\n",
+    "from blueqat.vqe import AnsatzBase, Vqe\n",
+    "\n",
+    "class QubitAnsatz(AnsatzBase):\n",
+    "    def __init__(self, hamiltonian):\n",
+    "        super().__init__(hamiltonian, 4)\n",
+    "        self.step = 1\n",
+    "\n",
+    "    def get_circuit(self, params):\n",
+    "        a, b, c, d = params\n",
+    "        return Circuit().ry(a)[0].rz(b)[0].ry(c)[1].rz(d)[1]\n",
+    "\n",
+    "h = -3*q(0)-3*q(1)-2*q(0)*q(1)\n",
+    "h = h.to_expr().simplify()\n",
+    "runner = Vqe(QubitAnsatz(h))\n",
+    "result = runner.run()\n",
+    "\n",
+    "print('Result by VQE')\n",
+    "print(runner.ansatz.get_energy_sparse(result.circuit))\n",
+    "\n",
+    "# Hamiltonian to matrix\n",
+    "mat = h.to_matrix()\n",
+    "\n",
+    "# Calculate by numpy\n",
+    "print('Result by numpy')\n",
+    "print(np.linalg.eigh(mat)[0][0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "DYsNMr6QvUnh"
+   },
+   "source": [
+    "We correctly the result. This time we just used 2qubits. But actually it is very difficult to get the right answer on bigger number of qubits. To compute much more efficiently we are using a new ansatz called QAOA ansatz for combinatorial optimization problem."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "etA_TEnsvWzL"
+   },
+   "source": [
+    "##QAOA\n",
+    "QAOA has a special form of ansatz especially to solve combinatorial optimization problem using the similar step of VQE. Now we try to use QAOA(Quantum Approximate Opitmization Alogirthm) in this chapter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "9e4vdEK9vZq8"
+   },
+   "source": [
+    "##2-5-1 Quantum Adiabatic Algorithm\n",
+    "QAA is an algorithm to change the state vector adiabatically to keep the ground state of the hamiltonian through the time evolution.\n",
+    "\n",
+    "We set the initial hamiltonian as $H_{start}$ and the final Hamiltonian as $H_{fin}$. t is time and T is the whole step of schedule.\n",
+    "\n",
+    "$$\n",
+    "H_{temp} = (1-\\frac{t}{T})H_{start} + \\frac{t}{T}H_{fin}\n",
+    "$$\n",
+    "\n",
+    "The hamiltoinan adiabatically changed according to the time t and the eigenstate of state vector keep the ground state if T is enough big.\n",
+    "\n",
+    "$$\n",
+    "H_{temp}\\mid \\psi \\rangle = E_{0temp}\\mid \\psi \\rangle\n",
+    "$$\n",
+    "\n",
+    "Time evolution is,\n",
+    "\n",
+    "$$\n",
+    "\\mid \\psi_{t+1} \\rangle = U \\mid \\psi_t \\rangle = e^{-iHt}  \\mid \\psi_t \\rangle\n",
+    "$$\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "FA9B9idIvgTH"
+   },
+   "source": [
+    "##QAOA\n",
+    "QAOA is basically using the idea of adiabatic process and transform it into a variational algorithm as ansatz of hamiltonian.\n",
+    "\n",
+    "![https___qiita-user-contents.imgix.net_https%3A%2F%2Fqiita-image-store.s3.ap-northeast-1.amazonaws.com%2F0%2F218694%2Fe10f1843-cc16-cdfe-e4a6-e2fbaab6df9f.png_ixlib=rb-1.2.png](https://qiita-image-store.s3.ap-northeast-1.amazonaws.com/0/218694/812819f5-0037-5a30-2690-8ed39c0b1a06.png)\n",
+    "https://app.quantumcomputing.com/\n",
+    "\n",
+    "The first H on the circuit shows the initial eigen state of hamiltonian X. CX-Rz-CX shows the weight of hamiltonian and Rz shows the bias of the hamiltonian. Rx is a time evolution of initial hamiltonian X.\n",
+    "\n",
+    "Let's just see the inside of QaoaAnsatz of blueqat. Hamiltonian consists of Z operator and automatically make a variational transformation of time evolution ansatz.\n",
+    "\n",
+    "\n",
+    "```python\n",
+    "class QaoaAnsatz(AnsatzBase):\n",
+    "    def __init__(self, hamiltonian, step=1, init_circuit=None):\n",
+    "        super().__init__(hamiltonian, step * 2)\n",
+    "        self.hamiltonian = hamiltonian.to_expr().simplify()\n",
+    "        if not self.check_hamiltonian():\n",
+    "            raise ValueError(\"Hamiltonian terms are not commutable\")\n",
+    "\n",
+    "        self.step = step\n",
+    "        self.n_qubits = self.hamiltonian.max_n() + 1\n",
+    "        if init_circuit:\n",
+    "            self.init_circuit = init_circuit\n",
+    "            if init_circuit.n_qubits > self.n_qubits:\n",
+    "                self.n_qubits = init_circuit.n_qubits\n",
+    "        else:\n",
+    "            self.init_circuit = Circuit(self.n_qubits).h[:]\n",
+    "        self.init_circuit.make_cache()\n",
+    "        self.time_evolutions = [term.get_time_evolution() for term in self.hamiltonian]\n",
+    "\n",
+    "    def check_hamiltonian(self):\n",
+    "        \"\"\"Check hamiltonian is commutable. This condition is required for QaoaAnsatz\"\"\"\n",
+    "        return self.hamiltonian.is_all_terms_commutable()\n",
+    "\n",
+    "    def get_circuit(self, params):\n",
+    "        c = self.init_circuit.copy()\n",
+    "        betas = params[:self.step]\n",
+    "        gammas = params[self.step:]\n",
+    "        for beta, gamma in zip(betas, gammas):\n",
+    "            beta *= np.pi\n",
+    "            gamma *= 2 * np.pi\n",
+    "            for evo in self.time_evolutions:\n",
+    "                evo(c, gamma)\n",
+    "            c.rx(beta)[:]\n",
+    "        return c\n",
+    "```\n",
+    "\n",
+    "On actual use, the library automatically do the calculation and you don't to implement a complicated formulation or time evolution.\n",
+    "\n",
+    "Blueqat do most of the process and what you just need to do is to formulate the hamiltonian as a combinatorial optimization with binary number of 0 and 1.\n",
+    "\n",
+    "Now we see an example of simple problem on qubo.\n",
+    "\n",
+    "```python\n",
+    "cost = -3*q(0)-3*q(1)-2*q(0)*q(1)\n",
+    "```\n",
+    "\n",
+    "This take obviously -8 as a result. It is very easy, now we can think about the social problem as binary number. q(0) and q(1) has -3 of bias and q(0)*q(1) has -2 as a weight.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "colab_type": "code",
+    "id": "mcfRj-T-vSfz",
+    "outputId": "73f0d2c4-2d2a-4fd2-f6b5-21822297b472"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(((1, 1), 0.9510486784530741), ((0, 0), 0.026525125765847812), ((1, 0), 0.011213097890539158), ((0, 1), 0.011213097890539146))\n"
+     ]
+    }
+   ],
+   "source": [
+    "from blueqat import vqe\n",
+    "from blueqat.pauli import qubo_bit as q\n",
+    "\n",
+    "h = -3*q(0)-3*q(1)-2*q(0)*q(1)\n",
+    "step = 2\n",
+    "\n",
+    "result = vqe.Vqe(vqe.QaoaAnsatz(h, step)).run()\n",
+    "print(result.most_common(12))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "pgvdZYqGvtHP"
+   },
+   "source": [
+    "We get combination of (1,1) as the probability of 96%."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "103_vqe_qaoa03.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/tutorial/400_chemistry_en.ipynb
+++ b/tutorial/400_chemistry_en.ipynb
@@ -1,593 +1,596 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "102vqe_qaoa02.ipynb",
-      "provenance": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "0DeQHhKHtIS9"
+   },
+   "source": [
+    "#VQE and quantum chemistry"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "0DeQHhKHtIS9",
-        "colab_type": "text"
-      },
-      "source": [
-        "#VQE and quantum chemistry"
-      ]
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "xoLga_-FtPxy"
+   },
+   "source": [
+    "On a quantum chemistry we can make hamiltonian using pauli operators and solve it using VQE. On a chemistry the advanced research on ansatz is done better than other problems and many researchers are working on this problem."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "ofFbnPOGqbKf"
+   },
+   "source": [
+    "##2-3-1 Install\n",
+    "We need to install blueqat, openfermionblueqat and openfermion."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 1000
     },
+    "colab_type": "code",
+    "id": "_NQIdXmptSJU",
+    "outputId": "db2075c6-9dbe-4e71-9b97-71ff39b2aa28"
+   },
+   "outputs": [
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "xoLga_-FtPxy",
-        "colab_type": "text"
-      },
-      "source": [
-        "On a quantum chemistry we can make hamiltonian using pauli operators and solve it using VQE. On a chemistry the advanced research on ansatz is done better than other problems and many researchers are working on this problem."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ofFbnPOGqbKf",
-        "colab_type": "text"
-      },
-      "source": [
-        "##2-3-1 Install\n",
-        "We need to install blueqat, openfermionblueqat and openfermion."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "_NQIdXmptSJU",
-        "colab_type": "code",
-        "outputId": "db2075c6-9dbe-4e71-9b97-71ff39b2aa28",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 1000
-        }
-      },
-      "source": [
-        "!pip3 install blueqat openfermionblueqat openfermion"
-      ],
-      "execution_count": 1,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Collecting blueqat\n",
-            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/f6/73/20f9cff48caee1f69190f2e1ea93c4d7d0a745fc48defb5d3072d8337583/blueqat-0.3.13-py3-none-any.whl (50kB)\n",
-            "\u001b[K     |████████████████████████████████| 51kB 1.7MB/s \n",
-            "\u001b[?25hCollecting openfermionblueqat\n",
-            "  Downloading https://files.pythonhosted.org/packages/e0/ef/d2a4242ef5f4ff518921dfd608d7841f476e947bc23efc25bd7c3ba0042d/openfermionblueqat-0.2.2-py3-none-any.whl\n",
-            "Collecting openfermion\n",
-            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/66/72/e058e3d8ececd54212bb98848e8e8227d4887fed6fe8d87f425a034add8b/openfermion-0.10.0.tar.gz (625kB)\n",
-            "\u001b[K     |████████████████████████████████| 634kB 6.6MB/s \n",
-            "\u001b[?25hRequirement already satisfied: scipy>=1.1.0 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.4.1)\n",
-            "Requirement already satisfied: numpy~=1.12 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.17.5)\n",
-            "Requirement already satisfied: h5py>=2.8 in /usr/local/lib/python3.6/dist-packages (from openfermion) (2.8.0)\n",
-            "Requirement already satisfied: future in /usr/local/lib/python3.6/dist-packages (from openfermion) (0.16.0)\n",
-            "Requirement already satisfied: jupyter in /usr/local/lib/python3.6/dist-packages (from openfermion) (1.0.0)\n",
-            "Requirement already satisfied: nbformat in /usr/local/lib/python3.6/dist-packages (from openfermion) (5.0.4)\n",
-            "Requirement already satisfied: networkx in /usr/local/lib/python3.6/dist-packages (from openfermion) (2.4)\n",
-            "Requirement already satisfied: matplotlib in /usr/local/lib/python3.6/dist-packages (from openfermion) (3.1.3)\n",
-            "Collecting pubchempy\n",
-            "  Downloading https://files.pythonhosted.org/packages/aa/fb/8de3aa9804b614dbc8dc5c16ed061d819cc360e0ddecda3dcd01c1552339/PubChemPy-1.0.4.tar.gz\n",
-            "Requirement already satisfied: six in /usr/local/lib/python3.6/dist-packages (from openfermion) (1.12.0)\n",
-            "Requirement already satisfied: qtconsole in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (4.6.0)\n",
-            "Requirement already satisfied: ipywidgets in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (7.5.1)\n",
-            "Requirement already satisfied: jupyter-console in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (5.2.0)\n",
-            "Requirement already satisfied: nbconvert in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (5.6.1)\n",
-            "Requirement already satisfied: ipykernel in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (4.6.1)\n",
-            "Requirement already satisfied: notebook in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (5.2.2)\n",
-            "Requirement already satisfied: traitlets>=4.1 in /usr/local/lib/python3.6/dist-packages (from nbformat->openfermion) (4.3.3)\n",
-            "Requirement already satisfied: jsonschema!=2.5.0,>=2.4 in /usr/local/lib/python3.6/dist-packages (from nbformat->openfermion) (2.6.0)\n",
-            "Requirement already satisfied: jupyter-core in /usr/local/lib/python3.6/dist-packages (from nbformat->openfermion) (4.6.2)\n",
-            "Requirement already satisfied: ipython-genutils in /usr/local/lib/python3.6/dist-packages (from nbformat->openfermion) (0.2.0)\n",
-            "Requirement already satisfied: decorator>=4.3.0 in /usr/local/lib/python3.6/dist-packages (from networkx->openfermion) (4.4.1)\n",
-            "Requirement already satisfied: pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 in /usr/local/lib/python3.6/dist-packages (from matplotlib->openfermion) (2.4.6)\n",
-            "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.6/dist-packages (from matplotlib->openfermion) (0.10.0)\n",
-            "Requirement already satisfied: kiwisolver>=1.0.1 in /usr/local/lib/python3.6/dist-packages (from matplotlib->openfermion) (1.1.0)\n",
-            "Requirement already satisfied: python-dateutil>=2.1 in /usr/local/lib/python3.6/dist-packages (from matplotlib->openfermion) (2.6.1)\n",
-            "Requirement already satisfied: pygments in /usr/local/lib/python3.6/dist-packages (from qtconsole->jupyter->openfermion) (2.1.3)\n",
-            "Requirement already satisfied: jupyter-client>=4.1 in /usr/local/lib/python3.6/dist-packages (from qtconsole->jupyter->openfermion) (5.3.4)\n",
-            "Requirement already satisfied: ipython>=4.0.0; python_version >= \"3.3\" in /usr/local/lib/python3.6/dist-packages (from ipywidgets->jupyter->openfermion) (5.5.0)\n",
-            "Requirement already satisfied: widgetsnbextension~=3.5.0 in /usr/local/lib/python3.6/dist-packages (from ipywidgets->jupyter->openfermion) (3.5.1)\n",
-            "Requirement already satisfied: prompt-toolkit<2.0.0,>=1.0.0 in /usr/local/lib/python3.6/dist-packages (from jupyter-console->jupyter->openfermion) (1.0.18)\n",
-            "Requirement already satisfied: jinja2>=2.4 in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (2.11.1)\n",
-            "Requirement already satisfied: entrypoints>=0.2.2 in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (0.3)\n",
-            "Requirement already satisfied: mistune<2,>=0.8.1 in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (0.8.4)\n",
-            "Requirement already satisfied: pandocfilters>=1.4.1 in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (1.4.2)\n",
-            "Requirement already satisfied: testpath in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (0.4.4)\n",
-            "Requirement already satisfied: defusedxml in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (0.6.0)\n",
-            "Requirement already satisfied: bleach in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (3.1.0)\n",
-            "Requirement already satisfied: tornado>=4.0 in /usr/local/lib/python3.6/dist-packages (from ipykernel->jupyter->openfermion) (4.5.3)\n",
-            "Requirement already satisfied: terminado>=0.3.3; sys_platform != \"win32\" in /usr/local/lib/python3.6/dist-packages (from notebook->jupyter->openfermion) (0.8.3)\n",
-            "Requirement already satisfied: setuptools in /usr/local/lib/python3.6/dist-packages (from kiwisolver>=1.0.1->matplotlib->openfermion) (45.1.0)\n",
-            "Requirement already satisfied: pyzmq>=13 in /usr/local/lib/python3.6/dist-packages (from jupyter-client>=4.1->qtconsole->jupyter->openfermion) (17.0.0)\n",
-            "Requirement already satisfied: pexpect; sys_platform != \"win32\" in /usr/local/lib/python3.6/dist-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets->jupyter->openfermion) (4.8.0)\n",
-            "Requirement already satisfied: simplegeneric>0.8 in /usr/local/lib/python3.6/dist-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets->jupyter->openfermion) (0.8.1)\n",
-            "Requirement already satisfied: pickleshare in /usr/local/lib/python3.6/dist-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets->jupyter->openfermion) (0.7.5)\n",
-            "Requirement already satisfied: wcwidth in /usr/local/lib/python3.6/dist-packages (from prompt-toolkit<2.0.0,>=1.0.0->jupyter-console->jupyter->openfermion) (0.1.8)\n",
-            "Requirement already satisfied: MarkupSafe>=0.23 in /usr/local/lib/python3.6/dist-packages (from jinja2>=2.4->nbconvert->jupyter->openfermion) (1.1.1)\n",
-            "Requirement already satisfied: webencodings in /usr/local/lib/python3.6/dist-packages (from bleach->nbconvert->jupyter->openfermion) (0.5.1)\n",
-            "Requirement already satisfied: ptyprocess; os_name != \"nt\" in /usr/local/lib/python3.6/dist-packages (from terminado>=0.3.3; sys_platform != \"win32\"->notebook->jupyter->openfermion) (0.6.0)\n",
-            "Building wheels for collected packages: openfermion, pubchempy\n",
-            "  Building wheel for openfermion (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
-            "  Created wheel for openfermion: filename=openfermion-0.10.0-cp36-none-any.whl size=731375 sha256=a6a7b18652f246d94640f5fa1a2a85b9d71d28a0ea20032213626d14f8ed3f0f\n",
-            "  Stored in directory: /root/.cache/pip/wheels/3c/49/cd/098bb337ffcbb70021864403773043df332c065590873f1813\n",
-            "  Building wheel for pubchempy (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
-            "  Created wheel for pubchempy: filename=PubChemPy-1.0.4-cp36-none-any.whl size=13825 sha256=6f935bbf877c8746569afa0d242dedb965bea20387048f6839b9f8ef47d91339\n",
-            "  Stored in directory: /root/.cache/pip/wheels/10/4d/51/6b843681a9a5aef35f0d0fbce243de46f85080036e16118752\n",
-            "Successfully built openfermion pubchempy\n",
-            "Installing collected packages: blueqat, pubchempy, openfermion, openfermionblueqat\n",
-            "Successfully installed blueqat-0.3.13 openfermion-0.10.0 openfermionblueqat-0.2.2 pubchempy-1.0.4\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "HHLJDoRXtXta",
-        "colab_type": "text"
-      },
-      "source": [
-        "##2-3-2 Coding\n",
-        "Here we use a prepared data provided by openfermion."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "hDacEDd6tVIK",
-        "colab_type": "code",
-        "outputId": "cdb33658-119e-4c37-caf6-04d06ba417b7",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 283
-        }
-      },
-      "source": [
-        "from blueqat import *\n",
-        "from openfermion import *\n",
-        "from openfermionblueqat import*\n",
-        "import numpy as np\n",
-        "\n",
-        "def get_molecule(bond_len):\n",
-        "  geometry = [('H',(0.,0.,0.)),('H',(0.,0.,bond_len))]\n",
-        "\n",
-        "  description = format(bond_len)\n",
-        "  molecule = MolecularData(geometry, \"sto-3g\",1,description=description)\n",
-        "\n",
-        "  molecule.load()\n",
-        "  return molecule\n",
-        "\n",
-        "x = [];e=[];fullci=[]\n",
-        "for bond_len in np.arange(0.2,2.5,0.1):\n",
-        "  m = get_molecule(\"{:.2}\".format(bond_len))\n",
-        "  h = bravyi_kitaev(get_fermion_operator(m.get_molecular_hamiltonian()))\n",
-        "  runner = vqe.Vqe(UCCAnsatz(h,6,Circuit().x[0]))\n",
-        "  result = runner.run()\n",
-        "  x.append(bond_len)\n",
-        "  e.append(runner.ansatz.get_energy(result.circuit,runner.sampler))\n",
-        "  fullci.append(m.fci_energy)\n",
-        "\n",
-        "%matplotlib inline\n",
-        "import matplotlib.pyplot as plt\n",
-        "plt.plot(x,fullci)\n",
-        "plt.plot(x,e,\"o\")"
-      ],
-      "execution_count": 0,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "[<matplotlib.lines.Line2D at 0x7fd883233c88>]"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 2
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYMAAAD5CAYAAADFqlkBAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0\ndHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nO3de3hc1X3u8e9vdB1b1sWWZN2sGIMx\nGMfBRTgmEIKDCQkJt6QB0uSUpE2dJqW0SfOcktISQnrhNE9KoU1O45I8IUl7EjeBYAqUGodLLg0g\nwBiMARsTsHyVZUu+6D7zO3/MCGRpj0bSjGakmffzPHpmz569Zy0243lnr7X22ubuiIhIfgtluwIi\nIpJ9CgMREVEYiIiIwkBERFAYiIgICgMREQEK0/EmZvZ+4HagALjT3W8d8foXgE8Dg0A78Hvu/nqy\n962urvaFCxemo4oiInnh6aefPujuNRPdL+UwMLMC4BvARUAb8JSZbXD3F4dt9izQ4u7dZvZZ4O+B\nq5O998KFC2ltbU21iiIiecPMkv7QDpKOZqKVwA533+nu/cAPgcuHb+Duj7h7d/zpr4GmNJQrIiJp\nko4waAR2DXveFl+XyO8DD6ahXBERSZO09BmMl5l9AmgB3jPGNmuBtQDNzc0ZqpmISH5Lx5nBbmDB\nsOdN8XUnMLM1wI3AZe7el+jN3H2du7e4e0tNzYT7QEREZBLSEQZPAYvN7CQzKwauATYM38DMVgDf\nIhYEB9JQpoiIpFHKYeDug8B1wEPANmC9u281s1vM7LL4Zl8DyoD/MLPNZrYhwdulbst6uG0Z3FwZ\ne9yyfsqKEhHJFWnpM3D3B4AHRqy7adjymnSUk9SW9XDf9TDQE3vetSv2HGD5VRmpgojITJRbVyBv\nuuWtIBgy0BNbLyIiCeVWGHS1TWy9iIgAuRYGFQmuZUu0XkREgFwLgwtvgqLwieuKwrH1IiKSUG6F\nwfKr4NI76CyaTxSDigVw6R3qPBYRSSKjVyBnxPKr+NHhs/i7B19iyw3vo7y0KNs1EhGZ9nLrzCCu\nsSrWVLSnsyfJliIiAjkaBg2VCgMRkYnIyTBoiofB7sMKAxGR8cjJMKguK6G4IMTuzt5sV0VEZEbI\nyTAIhYz6ylJ2q5lIRGRccjIMABoqwuozEBEZp5wNg8aqsPoMRETGKWfDoKEyzP6jvQxEotmuiojI\ntJezYdBUGcYd9nWpE1lEJJmcDYOhaw3UiSwiklzOhsHQVcjqNxARSS5nw6C+ohTQmYGIyHjkbBiU\nFhVQXVai4aUiIuOQs2EA0KgLz0RExiW3w6AqrDAQERmHnA6DoauQ3T3bVRERmdbSEgZm9n4ze9nM\ndpjZDQGvl5jZj+KvP2FmC9NRbjKNVWF6B6IcOt6fieJERGaslMPAzAqAbwAfAJYCHzOzpSM2+33g\nsLufAtwG/J9Uyx2PRl1rICIyLuk4M1gJ7HD3ne7eD/wQuHzENpcDd8WXfwxcaGaWhrLHpJvciIiM\nTzrCoBHYNex5W3xd4DbuPgh0AfOC3szM1ppZq5m1tre3p1SxpviFZ2268ExEZEzTrgPZ3de5e4u7\nt9TU1KT0XhXhImYVF7BHN7kRERlTOsJgN7Bg2POm+LrAbcysEKgAOtJQ9pjMjMbKMLs7u6e6KBGR\nGS0dYfAUsNjMTjKzYuAaYMOIbTYA18aXfxv4mWdovGdDZVhnBiIiSaQcBvE+gOuAh4BtwHp332pm\nt5jZZfHNvg3MM7MdwBeAUcNPp4ouPBMRSa4wHW/i7g8AD4xYd9Ow5V7go+koa6IaK8McOt5PT3+E\ncHFBNqogIjLtTbsO5HTTtQYiIsnlfBjoWgMRkeRyPgzevMmNwkBEJKGcD4P5c0ooCJnueCYiMoac\nD4PCghB15aVqJhIRGUPOhwFAQ2UpbQoDEZGE8iIMGivDOjMQERlDXoRBQ2WYfV29RKK6yY2ISJC8\nCIPGqjCDUefAUU1LISISJC/CYOhaA40oEhEJlhdh0KSrkEVExpQXYdCgMBARGVNehMHskkIqZxVp\nRJGISAJ5EQYQG16qPgMRkWB5Ewa6yY2ISGJ5Ewax21/2kKEbrImIzCh5FQbH+gY50juY7aqIiEw7\n+RMGVbrWQEQkkbwJAw0vFRFJLG/CoFF3PBMRSShvwmDe7GKKC0M6MxARCZBSGJjZXDPbaGbb449V\nAducaWb/Y2ZbzWyLmV2dSpmTFQrZmyOKRETkRKmeGdwAbHL3xcCm+PORuoHfdfczgPcD/2hmlSmW\nOykNlaXqQBYRCZBqGFwO3BVfvgu4YuQG7v6Ku2+PL+8BDgA1KZY7KbrJjYhIsFTDYL67740v7wPm\nj7Wxma0EioFXUyx3Uhoqwxw42kffYCQbxYuITFuFyTYws4eBuoCXbhz+xN3dzBJe3mtm9cD3gWvd\nPTrGdmuBtQDNzc3JqjchQyOK9nX18rZ5s9P63iIiM1nSMHD3NYleM7P9Zlbv7nvjX/YHEmxXDtwP\n3Ojuv05S3jpgHUBLS0ta545oHHaTG4WBiMhbUm0m2gBcG1++Frh35AZmVgzcA3zP3X+cYnkpefMq\nZPUbiIicINUwuBW4yMy2A2vizzGzFjO7M77NVcD5wCfNbHP878wUy52UuopSQGEgIjJS0maisbh7\nB3BhwPpW4NPx5R8AP0ilnHQpKSygdk6JRhSJiIyQN1cgD2nQhWciIqPkXRg0VukmNyIiI+VfGMTP\nDKJR3eRGRGRIXoZB/2CUjuP92a6KiMi0kZdhABpRJCIyXN6FQUOl7ngmIjJS3oXB0IVnGl4qIvKW\nvAuD8tJCykoK1UwkIjJM3oWBmW5yIyIyUt6FAegmNyIiI+VlGDRWhdnTpTAQERmSl2HQUBmms3uA\n432D2a6KiMi0kJdhMHStgUYUiYjE5HUYtCkMRESAfA0DXWsgInKCvAyD2jmlFIZMI4pEROLyMgwK\nQkZdRanODERE4vIyDEA3uRERGS5vw6CpUje5EREZkrdh0FAZZt+RXgYj0WxXRUQk6/I2DBqrwkSi\nzv6jfdmuiohI1uVtGOi+BiIib0k5DMxsrpltNLPt8ceqMbYtN7M2M/vnVMtN1Vt3POvOck1ERLIv\nHWcGNwCb3H0xsCn+PJGvAo+nocyUNVSWAqgTWUSE9ITB5cBd8eW7gCuCNjKzs4D5wH+nocyUzSou\nZO7sYtrUTCQikpYwmO/ue+PL+4h94Z/AzELA14EvJnszM1trZq1m1tre3p6G6iXWWBnWhWciIkDh\neDYys4eBuoCXbhz+xN3dzDxgu88BD7h7m5mNWZa7rwPWAbS0tAS9V9o0VJbyavvxqSxCRGRGGFcY\nuPuaRK+Z2X4zq3f3vWZWDxwI2Owc4N1m9jmgDCg2s2PuPlb/wpRrrJzFz7cfxN1JFlIiIrksHc1E\nG4Br48vXAveO3MDdP+7uze6+kFhT0feyHQQQOzPo7o/Q2T2Q7aqIiGRVOsLgVuAiM9sOrIk/x8xa\nzOzONLz/lGmqGhpeqn4DEclv42omGou7dwAXBqxvBT4dsP67wHdTLTcd3rzwrLOHZY0VWa6NiEj2\n5O0VyKDbX4qIDMnrMJg7u5jSopCmpBCRvJfXYWBmNFSG2dOlMBCR/JbXYQCxpiKdGYhIvlMYVIbZ\nrfmJRCTP5X0YNFSGOXisj96BSLarIiKSNXkfBkMjivZ26exARPJX3oeBbnIjIqIwGHYVsm5yIyL5\nK+/DYH55KWaoE1lE8lreh0FxYYj5c0rVTCQieS3vwwBis5dqSgoRyWcKA6CxapZmLhWRvKYwIHZm\nsLerh2h0Sm+sJiIybSkMgKbKMAMRp/1YX7arIiKSFQoDoFE3uRGRPKcwQBeeiYgoDNBNbkREFAbA\nnNIi5pQWqplIRPKWwiCusTKsMwMRyVsKg7jGyjBt6jMQkTyVUhiY2Vwz22hm2+OPVQm2azaz/zaz\nbWb2opktTKXcqdBYpTMDEclfqZ4Z3ABscvfFwKb48yDfA77m7qcDK4EDKZabduf3PsID0c/hN1fC\nbctgy/psV0lEJGNSDYPLgbviy3cBV4zcwMyWAoXuvhHA3Y+5+/SaL3rLei545a9pCh3EcOjaBfdd\nr0AQkbyRahjMd/e98eV9wPyAbU4FOs3sbjN71sy+ZmYFKZabXptuoTAyYgrrgR7YdEt26iMikmGF\nyTYws4eBuoCXbhz+xN3dzIIm9ykE3g2sAN4AfgR8Evh2gvLWAmsBmpubk1UvPbraJrZeRCTHJA0D\nd1+T6DUz229m9e6+18zqCe4LaAM2u/vO+D4/BVaRIAzcfR2wDqClpSUzM8dVNMWahoLWi4jkgVSb\niTYA18aXrwXuDdjmKaDSzGriz98LvJhiuel14U1QFD5xXVE4tl5EJA+kGga3AheZ2XZgTfw5ZtZi\nZncCuHsE+CKwycyeBwz41xTLTa/lV8Gld9A3u5GoG93herj0jth6EZE8YO7Tdw7/lpYWb21tzVh5\nkajT8tcbuWBJLbddfWbGyhURSRcze9rdWya6n65AHqYgZLzn1Boee6WdiG50IyJ5RGEwwurTajl0\nvJ8tbZ3ZroqISMYoDEY4f3ENIYNHXpp2F0mLiEwZhcEIVbOLWdFcxSMvt2e7KiIiGaMwCLB6SQ3P\n7+7iwNHe5BuLiOQAhUGA1afVAvCYzg5EJE8oDAIsrS+ndk4JjyoMRCRPKAwCmBmrl9Ty+CvtDESi\n2a6OiMiUUxgksPq0Go72DfL064ezXRURkSmnMEjg3FOqKSowHnlZQ0xFJPcpDBKYU1rE2Qvn8uhL\n6jcQkdynMBjD6iW1vLz/KLt1b2QRyXEKgzGsPi0267auRhaRXKcwGMPJNWU0VYV5VP0GIpLjFAZj\nGBpi+ssdHfQORLJdHRGRKaMwSOK9p9XSMxDhydcOZbsqIiJTRmGQxKpF8ygpDGmIqYjkNIVBEuHi\nAs45eZ46kUUkpykMxmH1klp+09HNawePZ7sqIiJTQmEwDquXxGYx1dmBiOQqhcE4NM+bxck1s9Vv\nICI5S2EwTquX1PLEzkN09w9muyoiImmXchiY2Vwz22hm2+OPVQm2+3sz22pm28zsDjOzVMvOpNWn\n1dIfifLLHR3ZroqISNql48zgBmCTuy8GNsWfn8DM3gWcCywHlgFnA+9JQ9kZc/bCucwuLlBTkYjk\npHSEweXAXfHlu4ArArZxoBQoBkqAImB/GsrOmOLCEOctrubRlw7g7tmujohIWqUjDOa7+9748j5g\n/sgN3P1/gEeAvfG/h9x9WxrKzqjVS2rZ09XLK/uPZbsqIiJpVTiejczsYaAu4KUbhz9xdzezUT+b\nzewU4HSgKb5qo5m9291/HrDtWmAtQHNz83iqlzEXDA0xffkAS+rmZLk2IiLpM64zA3df4+7LAv7u\nBfabWT1A/DGoUf1K4NfufszdjwEPAuckKGudu7e4e0tNTc3k/qumSF1FKafXl/MzXW8gIjkmHc1E\nG4Br48vXAvcGbPMG8B4zKzSzImKdxzOumQhg9ZIann79MF09A9muiohI2qQjDG4FLjKz7cCa+HPM\nrMXM7oxv82PgVeB54DngOXe/Lw1lZ9x7T6slEnV+sf1gtqsiIpI24+ozGIu7dwAXBqxvBT4dX44A\nn0m1rOngzAWVVISLeOTlA3xweX22qyMikha6AnmCCgtCnH9qDY++3E40qiGmIpIbFAaTsHpJDQeP\n9fHCnq5sV0VEJC0UBpPwnlNrMINHXmrPdlVERNJCYTAJ88pKeEdTpaamEJGcoTCYpNVLanmurZOO\nY33ZroqISMoUBpO0+rQa3OHx7WoqEpGZT2EwScsaKqguK+Fn6jcQkRygMJikUMi4YEkNj7/SzmAk\nmu3qiIikRGGQgtVLaunqGWDzrs5sV0VEJCUKgxSs7n+UX5Zcz1nfXQS3LYMt67NdJRGRSUl5Ooq8\ntWU9sx76PLOsJ/a8axfcd31seflV2auXiMgk6MxgsjbdAgM9J64b6ImtFxGZYRQGk9XVNrH1IiLT\nmMJgsiqaJrZeRE60ZX2sr+3mysz0uU2mvMnWMdP7pYH6DCbrwptifQTDmop6KMHffSOzslgtkRlh\ny/oT//1MpM9ty/pYc2xXW+zH14U3jW+fiZY32ToG7Of3Xc/AYJTepR8hEnEGolEGIx77i0YZjDrh\nl35C4+M3EIpkpx/S3KfvNMwtLS3e2tqa7WokNuxD2V/WwP/uvILSFddw60eWZ7tmItPbbctiX3Yj\nVSyAz7+QeL+RX7QARWG49I6EX5jujt+2jNCR0U24vbMaePSSR+gbjNA7EKF3IErvQIS+wSjXPvEh\nKvr3jdrnYEEtf1r/A/ojUfoHY38DkSj9kSgDg1F+0reWekbf/KotWs15/Xck/E/7RfH1NIUCbpqV\n7JiMYGZPu3vLuHeI05lBKpZf9eYHsBiY/+A2vvXYTi47s4F3nVyd3bqJZMpkfqmPo8+tdyDCkZ4B\njvQO0NUzyJHeAd754E3MChi40bHhL/lC60K6+wc53heJPfZH6O4bpHsgwqvFbWCjiys+vpc//MHT\ngVW5rmRf4D5zI+109w9SXBhiTmkhJYUhigpCFMcf67Z2BL5fY6iDv/zg6RSGjIKCEEUho7AgRGHI\nKCwwGu8O3i9T/ZAKgzT6/JpT+a8X9vGlu5/noT89n9KigmxXSWRqjaMpZTAS5XD3AIeO99NxvI9D\nx/u5oLSOst69o95un1Xzob9+mCO9A/QPjr6yf2fJ3sAv6KrBA3T2DDC7uICGymJmlxQwq7iQ2cUF\nzCop5HhrPXP6Rpc3UNbA/Z85j9KigthfYYiS+GPojgWBZy+hiibu/ty5iY9JW1PgflbRxKffvSjx\nfpuC98tUP6TCII1Kiwr4uw+/nd/51yf4x4e3c8MHTst2lUTGbwK/8CNRp+NYH5X/fTPFAb/U2396\nI1dvrOXQ8X66egYY2Rp9WehKbi26k1nW/+a6Pivhwflruah2PhXhIsrDhZSXFlEeLqK8tJDycBGR\n9Y2Eju0eVZ9QRRP3/tEYX9DzbwlsXiq5+GbOaKgI3iegX5CicGz9WDK9X5ooDNLsXSdXc3XLAv71\n5zv50PJ6ljUm+KCJTCcBv/Aj917PM785zNMVa9jX1cv+I73sO9LLvq5eDhztIxJ1dpbsDvylPi/a\nzul15cydXczc2cXMKyt+a3l2CXNnr6Hk1TPhka++GT4lF97Ep5I1L73v5sl9YQ6970SasyazTzb2\nSxN1IE+Bru4B1tz2GLVzSrj3j86lsEAjeCWDkvzCj0ad/Ud7eb2jmzcOdbPrUDefevJS5g7uH/VW\nQ52eZSWF1FWUUldeyvzyUuoqSqgrL+W3f/4Bwt17Rtdhgp2e6fzvy3eT7UBWGEyRB5/fy2f/7Rm+\n9IHT+Mx7Ts52dSRfBIy2GQiV8tMFf879nMcbh7ppO9RD/7CZdkMGO0o+TojR3wWOcfxLBykrSdCI\nMInRPTK1sjKayMw+CtwMnA6sdPfAb24zez9wO1AA3Onut6ZS7kzwgbfXc/EZ8/mHja9w8Rl1LKye\nne0qyUyU5Ffw0d4BXm0/zvb9R9nRfow/aL2R6siJbfhF0V7Off0b3DXvbE6rm8NFS+fTPHfWm38N\nlWFCdyTu9EwYBJD1pg1Jn5TODMzsdCAKfAv4YlAYmFkB8ApwEdAGPAV8zN1fTPb+M/nMAGD/kV7W\nfP0xljVW8O9/8E7MAhpXJT+k40IpYDBUyr3Nf85PI+ey48Ax9nb1vvlacUGIl4o+FvgLHwxuHmOq\ndf3CzxlZOTNw923xwsfabCWww913xrf9IXA5kDQMZrr55aV86ZLT+Yt7nmd96y6uPrs521WSbJjA\nlazRqPNax3Fe3HOE8+//KypGjNQpjPay6rVv8N3qlZyzaB4n15axuLaMU2rLaJ47K+Ev/KTDE/UL\nP+9lYjRRIzD809kGvDPRxma2FlgL0Nw88788rzl7Afdu3s3f3L+N1UtqqS0vzXaVJNMSzHDrm77C\n1nkXs3VPF1v3HGHrniNs23uE7v4IADsTXPTUYB3c98fnBZeVyvDEYRdRSv5JGgZm9jBQF/DSje5+\nb7or5O7rgHUQayZK9/tnWihk/N2H3877b/85N9+3lW9+/KxsV0kyLcEVpN65mw/90y8AmF1cwNKG\ncq5qWcDShnLOaCjHftQUuK+N9Stfv/BlkpKGgbuvSbGM3cCCYc+b4uvyxqKaMv7kwsV87aGXeWjr\nPi4+IyhbZUYYR9u/u/Objm6efeMwz77RyR+HqqmNto96q6Ml8/nnj6zgjIYK3jZ3FqHQiNOAC788\n+TH1+vKXCcpEM9FTwGIzO4lYCFwD/E4Gyp1W1p6/iP/cspe/+ukLrFo0j4pwUbarJBOVoO2/uz9C\na/kann2jk2d3HWbzrk46uweA2C/++XN/j88cuZ2i6FudvRSFqfjQV/nQ8obE5elXvmRQqqOJrgT+\nCagBOoHN7n6xmTUQG0J6SXy7S4B/JDa09Dvu/jfjef+ZPppopC1tnVzxjV9yzcpm/vbKt2e7OjJR\nCWbaHLowywwW15axYkEVK5orWdFcxSm1ZRSETBdKScboorMZ4m8f2Ma6x3fyw7WrWLVoXrarI0n0\nD0Z5fncnT752mD989CwswYVZv/rEDpY3VTCnVGd8kl2awnqG+PyaUxl89kcs/P6f4H4w1hmoX4mZ\nl+CX+rG+QZ5+/TCtvznEk68dYvOuTvris2deGa6mzke3/VtFE+eeoinLZWZTGGRY+KWfcGP0Xyjw\n7NzNSAhs+++/5zpuf+gl/u+hs4g6FISMMxrK+cSqt3H2wipaFs6leuffZnVWSZGppDDItE23UBAZ\nPeacTbcoDDLgwJFeyh788qgbpBR7H5/s/T4Fq6/m7JPmsqK5avQ0DOrQlRymMMi0RGPOu9qCri+S\nZJJ0zO7r6uWJ1zr49c4Onth5iJ0Hj7OzZE/gxVw1kXa+8L4lY5enYZuSoxQGmVYRPF3Abp/H9x/c\nxufXnKo7pI1XQHNPdMP1PP2bQ/y4/1088VoHv+noBmBOaSErF87lYyubGXyykeKAG6Rk6o5SItOR\nwiDTAqYL8MIwv6j/LN96bCc/23aAr1/1DpY3VWaxkjODb7oFG9HcExrsob71azwY+iYrT5rHJ1a9\njVWL5nF6fXlsiCdA5c1q+xcZQWGQaQHtznbhTVyz/CrqXj7ADT95niu/+Ss+d8HJ/PF7F1NcqBvj\nDHF3Xm0/xhOvxUb63Jagaa0x1MGzN73vrS//kdT2LzKKrjOYZrp6BvjKfVu5+5ndnF5fztc/+g6W\nNpRnu1pTL6DtP7Lso7y07whPxr/8n3ztEB3HY/fMrZlTwn/555gXcHeuKb3Llsg0p4vOcszGF/fz\npbufp6unn+vfu5g/vOBkirb+ODd/zQbMpd9nJdzka/lR7zkANFWFWXnSXN550lxWnjSPhfNmYc//\nh+bgFxlBYZCDDh/v56YNW7nvuT1cN+8ZvtD3DUKDufHF5+683tHN5l2dXPDAaioHRv/CP1w0n8cu\neYSzT5pLY2U4+I00zYPICRQGOez+LXtZcfd5NHBw9IvTsUkk4Av68MlXsLmtk81vdLJ5VyfPtb01\nmdvOko8TskncnUtERtF0FDnsg8vr8bs7Al/zrjY86qOnP86WLevxDddjg28N9+y9+zq+3P8sG6Ln\nETI4df4cLl5ax5nNlZy5oBL7YWPw9Rca6imSMQqDGcISXZ8QnccHv7qRMxdUvjlT5pkLKk+cInuy\nTSlj7Nc3GOGNju7YRVztx3nt4DFeO3ic2/d9iQZOHO5ZSh9/M+cePnbVF3l7U8XoK3snO2+/iKSN\nwmCmCLg+IVoYZteyL3JJtI5nXu/k9k3bGWr1O6W2jBULKrmy8Fes2vqVt/oaEsyFFI06A9EoAxFn\nYDBK6IX/YM7GPzthv/57ruM7j73Kv/esou1wN9FhLTvVZSUsqplNPcFnMHP69nHOyQlmadVQT5Gs\nU5/BTJLkF/7R3gG2tHXx7BuHeeaNTp594zD3DX6WptDovoY9VHMx32QgEguASPTEz8Eviq8P3G9/\nqIavnrKeRdWzWVRTxknVszmpZjblQ1M3J5jzf1r2bYjkIHUgyyjuDl+pSjgH/y1n/ZKighBFBRZ/\nfGv5kxtXBO6XtFM3YJjoTB71JDLTqANZRjGzhHMhWUUTX770jMQ7Pxm8X9JOXTX5iMxICoNcF9DX\nMK7O2cnuB5rZU2QG0sQ3uW75VbEmmooFgMUex9NkM9n9RGRGUp+BiEgOmWyfgc4MREQktTAws4+a\n2VYzi5pZYBKZ2QIze8TMXoxv+yeplCkiIumX6pnBC8CHgcfH2GYQ+DN3XwqsAv7IzJamWK6IiKRR\nSqOJ3H0bxIcwJt5mL7A3vnzUzLYBjcCLqZQtIiLpk9E+AzNbCKwAnshkuSIiMrakZwZm9jBQF/DS\nje5+73gLMrMy4CfAn7r7kTG2WwusjT89ZmYvj7eMGagagualzms6JsF0XEbTMRmtGnjbZHZMy9BS\nM3sU+KK7B44DNbMi4D+Bh9z9H1IuMEeYWetkhoDlMh2TYDouo+mYjJbKMZnyZiKLdSh8G9imIBAR\nmZ5SHVp6pZm1AecA95vZQ/H1DWb2QHyzc4H/BbzXzDbH/y5JqdYiIpJWqY4muge4J2D9HuCS+PIv\ngGlyG65pZ122KzAN6ZgE03EZTcdktEkfk2k9HYWIiGSGpqMQERGFQSaY2fvN7GUz22FmNwS8/kkz\nax/Wp/LpbNQzk8zsO2Z2wMwCb39mMXfEj9kWM/utTNcx08ZxTC4ws65hn5Ocv0n0eKazybfPyjiP\nycQ/K+6uvyn8AwqAV4FFQDHwHLB0xDafBP4523XN8HE5H/gt4IUEr18CPEisv2kV8ES26zwNjskF\nwH9mu54ZPib1wG/Fl+cArwT8+8mrz8o4j8mEPys6M5h6K4Ed7r7T3fuBHwKXZ7lOWefujwOHxtjk\ncuB7HvNroNLM6jNTu+wYxzHJO+6+192fiS8fBYamsxkurz4r4zwmE6YwmHqNwPD7R7YR/D/uI/FT\n3B+b2YLMVG1aG+9xyzfnmNlzZvagmY1x39LcM8Z0Nnn7WUkyxc+EPisKg+nhPmChuy8HNgJ3Zbk+\nMj09A7zN3d8B/BPw0yzXJ3M3lJMAAAE9SURBVGPGO51NPklyTCb8WVEYTL3dwPBf+k3xdW9y9w53\n74s/vRM4K0N1m86SHrd84+5H3P1YfPkBoMjMqrNcrSkXn87mJ8C/ufvdAZvk3Wcl2TGZzGdFYTD1\nngIWm9lJZlYMXANsGL7BiPbNy4i1Aea7DcDvxkeKrAK6PDYdet4ys7r49C6Y2Upi/347slurqTXO\n6Wzy6rMynmMymc9KSlcgS3LuPmhm1wEPERtZ9B1332pmtwCt7r4BuN7MLiN2I6BDxEYX5TQz+3/E\nRjxUx6c0+TJQBODu/wI8QGyUyA6gG/hUdmqaOeM4Jr8NfNbMBoEe4BqPDx3JYUPT2TxvZpvj6/4C\naIa8/ayM55hM+LOiK5BFRETNRCIiojAQEREUBiIigsJARERQGIiICAoDERFBYSAiIigMREQE+P/s\nes9znult7wAAAABJRU5ErkJggg==\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          }
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "XC1xaDwbtcxb",
-        "colab_type": "text"
-      },
-      "source": [
-        "We got a result on the H2 problem."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "3vw6h4eytfK2",
-        "colab_type": "text"
-      },
-      "source": [
-        "##2-3-3 Checking inside the coding\n",
-        "Using MoluculearData function on OpenFermion, we can use prepare data of Sto-3g on H2 molecule."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "U2xwZyAItaMu",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "def get_molecule(bond_len):\n",
-        "  geometry = [('H',(0.,0.,0.)),('H',(0.,0.,bond_len))]\n",
-        "\n",
-        "  description = format(bond_len)\n",
-        "  molecule = MolecularData(geometry, \"sto-3g\",1,description=description)\n",
-        "\n",
-        "  molecule.load()\n",
-        "  return molecule"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "jy8xNG4Etk2S",
-        "colab_type": "text"
-      },
-      "source": [
-        "Here we select 0.4 as the bond length between atoms. We get a formulation on second quantization."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "TO1lSYvbtikE",
-        "colab_type": "code",
-        "outputId": "51191d25-cec4-4d64-a0c5-99ddeebe83d8",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 646
-        }
-      },
-      "source": [
-        "m = get_molecule(0.4)\n",
-        "m.get_molecular_hamiltonian()"
-      ],
-      "execution_count": 0,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "() 1.322943021475\n",
-              "((0, 1), (0, 0)) -1.4820918858979102\n",
-              "((1, 1), (1, 0)) -1.4820918858979102\n",
-              "((2, 1), (2, 0)) -0.1187350527865787\n",
-              "((3, 1), (3, 0)) -0.1187350527865787\n",
-              "((0, 1), (0, 1), (0, 0), (0, 0)) 0.36843967630348756\n",
-              "((0, 1), (0, 1), (2, 0), (2, 0)) 0.08225771204699692\n",
-              "((0, 1), (1, 1), (1, 0), (0, 0)) 0.36843967630348756\n",
-              "((0, 1), (1, 1), (3, 0), (2, 0)) 0.08225771204699692\n",
-              "((0, 1), (2, 1), (0, 0), (2, 0)) 0.082257712046997\n",
-              "((0, 1), (2, 1), (2, 0), (0, 0)) 0.3626667179796745\n",
-              "((0, 1), (3, 1), (1, 0), (2, 0)) 0.082257712046997\n",
-              "((0, 1), (3, 1), (3, 0), (0, 0)) 0.3626667179796745\n",
-              "((1, 1), (0, 1), (0, 0), (1, 0)) 0.36843967630348756\n",
-              "((1, 1), (0, 1), (2, 0), (3, 0)) 0.08225771204699692\n",
-              "((1, 1), (1, 1), (1, 0), (1, 0)) 0.36843967630348756\n",
-              "((1, 1), (1, 1), (3, 0), (3, 0)) 0.08225771204699692\n",
-              "((1, 1), (2, 1), (0, 0), (3, 0)) 0.082257712046997\n",
-              "((1, 1), (2, 1), (2, 0), (1, 0)) 0.3626667179796745\n",
-              "((1, 1), (3, 1), (1, 0), (3, 0)) 0.082257712046997\n",
-              "((1, 1), (3, 1), (3, 0), (1, 0)) 0.3626667179796745\n",
-              "((2, 1), (0, 1), (0, 0), (2, 0)) 0.36266671797967454\n",
-              "((2, 1), (0, 1), (2, 0), (0, 0)) 0.08225771204699726\n",
-              "((2, 1), (1, 1), (1, 0), (2, 0)) 0.36266671797967454\n",
-              "((2, 1), (1, 1), (3, 0), (0, 0)) 0.08225771204699726\n",
-              "((2, 1), (2, 1), (0, 0), (0, 0)) 0.08225771204699728\n",
-              "((2, 1), (2, 1), (2, 0), (2, 0)) 0.38272169831413727\n",
-              "((2, 1), (3, 1), (1, 0), (0, 0)) 0.08225771204699728\n",
-              "((2, 1), (3, 1), (3, 0), (2, 0)) 0.38272169831413727\n",
-              "((3, 1), (0, 1), (0, 0), (3, 0)) 0.36266671797967454\n",
-              "((3, 1), (0, 1), (2, 0), (1, 0)) 0.08225771204699726\n",
-              "((3, 1), (1, 1), (1, 0), (3, 0)) 0.36266671797967454\n",
-              "((3, 1), (1, 1), (3, 0), (1, 0)) 0.08225771204699726\n",
-              "((3, 1), (2, 1), (0, 0), (1, 0)) 0.08225771204699728\n",
-              "((3, 1), (2, 1), (2, 0), (3, 0)) 0.38272169831413727\n",
-              "((3, 1), (3, 1), (1, 0), (1, 0)) 0.08225771204699728\n",
-              "((3, 1), (3, 1), (3, 0), (3, 0)) 0.38272169831413727"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 4
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "MCcUSNvltukv",
-        "colab_type": "text"
-      },
-      "source": [
-        "This is not a hamiltonian with pauli operator, so we need a transformation."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "sP1KphQktw8Z",
-        "colab_type": "text"
-      },
-      "source": [
-        "##2-3-4 Transformation\n",
-        "\n",
-        "Bravi-Kitaev transformation or Jordan–Wigner transformation are famous. Now we use the former BK transformation."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "3B3loOfutn2j",
-        "colab_type": "code",
-        "outputId": "99f7f869-64b7-4297-ac30-52d52b4147ff",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 272
-        }
-      },
-      "source": [
-        "h = bravyi_kitaev(get_fermion_operator(m.get_molecular_hamiltonian()))\n",
-        "print(h)"
-      ],
-      "execution_count": 0,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "(0.7407724940116754+0j) [] +\n",
-            "(0.041128856023498556+0j) [X0 Z1 X2] +\n",
-            "(0.041128856023498556+0j) [X0 Z1 X2 Z3] +\n",
-            "(0.041128856023498556+0j) [Y0 Z1 Y2] +\n",
-            "(0.041128856023498556+0j) [Y0 Z1 Y2 Z3] +\n",
-            "(0.23528824284103544+0j) [Z0] +\n",
-            "(0.23528824284103542+0j) [Z0 Z1] +\n",
-            "(0.18133335898983727+0j) [Z0 Z1 Z2] +\n",
-            "(0.18133335898983727+0j) [Z0 Z1 Z2 Z3] +\n",
-            "(0.14020450296633868+0j) [Z0 Z2] +\n",
-            "(0.14020450296633868+0j) [Z0 Z2 Z3] +\n",
-            "(0.18421983815174378+0j) [Z1] +\n",
-            "(-0.45353118471995524+0j) [Z1 Z2 Z3] +\n",
-            "(0.19136084915706864+0j) [Z1 Z3] +\n",
-            "(-0.45353118471995524+0j) [Z2]\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "xWER997LuB9V",
-        "colab_type": "text"
-      },
-      "source": [
-        "Now we got a hamiltonian with pauli operator, now we can solve it with VQE. To solve this efficiently we use UCC theory on ansatz. By using a prepared UCCansatz in blueqat we get,"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "97RcOB7Rt4_7",
-        "colab_type": "code",
-        "outputId": "730c7fd9-0eed-4349-edd0-24aae9f26ba5",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 714
-        }
-      },
-      "source": [
-        "runner = vqe.Vqe(UCCAnsatz(h,2,Circuit().x[0]))\n",
-        "result = runner.run(verbose = True)"
-      ],
-      "execution_count": 0,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "params: [0.05292822 0.69293649] val: -0.5142646866048539\n",
-            "params: [0.05292822 0.69293649] val: -0.5142646866048539\n",
-            "params: [1.05292822 0.69293649] val: 0.8011773974437459\n",
-            "params: [-1.56510578  0.69293649] val: -0.391150390234131\n",
-            "params: [0.05292822 0.69293649] val: -0.5142646866048539\n",
-            "params: [-0.56510575  0.69293649] val: -0.8977304830394611\n",
-            "params: [-0.56510575  0.69293649] val: -0.8977304830394611\n",
-            "params: [-0.56510575  1.69293649] val: 1.1263433928808557\n",
-            "params: [-0.56510575 -0.92509751] val: -0.3739824457207399\n",
-            "params: [-0.56510575  0.69293649] val: -0.8977304830394611\n",
-            "params: [-0.56510575  0.07490252] val: -0.6645405398129258\n",
-            "params: [-0.56510575  1.07490249] val: 0.6502494968493011\n",
-            "params: [-0.56510575  0.42650545] val: -0.3371306326723218\n",
-            "params: [-0.56510575  0.83883452] val: -0.5188368945182854\n",
-            "params: [-0.56510575  0.5911689 ] val: -0.723006612107723\n",
-            "params: [-0.56510575  0.74866458] val: -0.8515651952459188\n",
-            "params: [-0.56510575  0.69517091] val: -0.8981969317962648\n",
-            "params: [-0.56510575  0.70634301] val: -0.897747129510898\n",
-            "params: [-1.18313973  0.69740533] val: -0.746229241629738\n",
-            "params: [-0.56510575  0.69517091] val: -0.8981969317962648\n",
-            "params: [-1.18313973  0.69740533] val: -0.746229241629738\n",
-            "params: [0.43489423 0.69155555] val: -0.0675824851807392\n",
-            "params: [-0.56510575  0.69517091] val: -0.8981969317962648\n",
-            "params: [-0.18313976  0.69378997] val: -0.7188123204271055\n",
-            "params: [-0.80117372  0.69602439] val: -0.9049963420733075\n",
-            "params: [-0.80117372  0.69602439] val: -0.9049963420733075\n",
-            "params: [-0.80117372  1.69602439] val: 1.2621240755027043\n",
-            "params: [-0.80117372 -0.92200961] val: -0.291223954836067\n",
-            "params: [-0.80117372  0.69602439] val: -0.9049963420733075\n",
-            "params: [-0.80117372  0.07799041] val: -0.4433620633023846\n",
-            "params: [-0.80117372  1.07799039] val: 0.9809286764492423\n",
-            "params: [-0.80117372  0.45270877] val: -0.11675869413404844\n",
-            "params: [-0.80117372  0.84192241] val: -0.44127255704023494\n",
-            "params: [-0.80117372  0.60308609] val: -0.6771437588686717\n",
-            "params: [-0.80117372  0.75175247] val: -0.8578763018840084\n",
-            "params: [-0.80117372  0.70482634] val: -0.9083099960106484\n",
-            "params: [-0.80117372  0.70482634] val: -0.9083099960106484\n",
-            "params: [-1.03724168  0.70567982] val: -0.837079229404281\n",
-            "params: [-0.41920772  0.7034454 ] val: -0.8514285285577546\n",
-            "params: [-0.80117372  0.70482634] val: -0.9083099960106484\n",
-            "params: [-0.65527569  0.70429887] val: -0.9117470824158458\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "pogBuf8HuG9y",
-        "colab_type": "text"
-      },
-      "source": [
-        "After the optimizing process we get the minimized result. This time we use UCC ansatz with Hamiltonian."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "7aogyg6YuD6S",
-        "colab_type": "code",
-        "outputId": "48520c01-5ad1-4d42-fc6c-ccf395d1df9b",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        }
-      },
-      "source": [
-        "runner.ansatz.get_energy(result.circuit,runner.sampler)"
-      ],
-      "execution_count": 0,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "-0.9117470824158458"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 10
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gFgZVsk6uMXf",
-        "colab_type": "text"
-      },
-      "source": [
-        "Again this is the whole code for H2 UCCansatz"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "uP2XQ8j3uJnr",
-        "colab_type": "code",
-        "outputId": "83f553f0-957b-4660-b275-4e56a1ef0ab2",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 283
-        }
-      },
-      "source": [
-        "from blueqat import *\n",
-        "from openfermion import *\n",
-        "from openfermionblueqat import*\n",
-        "import numpy as np\n",
-        "\n",
-        "def get_molecule(bond_len):\n",
-        "  geometry = [('H',(0.,0.,0.)),('H',(0.,0.,bond_len))]\n",
-        "\n",
-        "  description = format(bond_len)\n",
-        "  molecule = MolecularData(geometry, \"sto-3g\",1,description=description)\n",
-        "\n",
-        "  molecule.load()\n",
-        "  return molecule\n",
-        "\n",
-        "x = [];e=[];fullci=[]\n",
-        "for bond_len in np.arange(0.2,2.5,0.1):\n",
-        "  m = get_molecule(\"{:.2}\".format(bond_len))\n",
-        "  h = bravyi_kitaev(get_fermion_operator(m.get_molecular_hamiltonian()))\n",
-        "  runner = vqe.Vqe(UCCAnsatz(h,6,Circuit().x[0]))\n",
-        "  result = runner.run()\n",
-        "  x.append(bond_len)\n",
-        "  e.append(runner.ansatz.get_energy(result.circuit,runner.sampler))\n",
-        "  fullci.append(m.fci_energy)\n",
-        "\n",
-        "%matplotlib inline\n",
-        "import matplotlib.pyplot as plt\n",
-        "plt.plot(x,fullci)\n",
-        "plt.plot(x,e,\"o\")"
-      ],
-      "execution_count": 0,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "[<matplotlib.lines.Line2D at 0x7fd876809668>]"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 11
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYMAAAD5CAYAAADFqlkBAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0\ndHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nO3de3hc1X3u8e9vdB1blmRbknWzMAZj\nMMSBIhwTCMHBBELDLU2AXE5IW+o2KaFNm+ccUrcESNvQ5klpaJKTuCRPyKUncRIuppgS43BJ0gYQ\nYAzGgMEOWL7KsiVfdJ/5nT9mhGVpj0bWjGakmffzPHpmz549sxab8bx7r732WubuiIhIfgtluwIi\nIpJ9CgMREVEYiIiIwkBERFAYiIgICgMREQEK0/EhZnYp8DWgALjb3e8Y9vpfATcAA0Ab8Efu/may\nz62qqvJ58+alo4oiInnh2Wef3efu1cf7vpTDwMwKgG8AFwOtwDNmtsbdXx6y2fNAs7t3mdmngX8G\nrk322fPmzaOlpSXVKoqI5A0zS3qgHSQdzURLgNfdfau79wE/Bq4cuoG7P+buXfGnvwUa01CuiIik\nSTrCoAHYPuR5a3xdIn8MPJyGckVEJE3Scs1grMzsE0Az8N5RtlkBrABoamrKUM1ERPJbOs4MdgBz\nhzxvjK87hpktB1YCV7h7b6IPc/dV7t7s7s3V1cd9DURERMYhHWHwDLDAzE40s2LgOmDN0A3M7Czg\n28SCYG8ayhQRkTRKOQzcfQC4EXgE2AysdvdNZna7mV0R3+wrQBnwUzPbYGZrEnxc6jauhjvPgFsr\nY48bV09YUSIiuSIt1wzcfS2wdti6W4YsL09HOUltXA0P3gT93bHnndtjzwEWX5ORKoiITEW5dQfy\n+tuPBsGg/u7YehERSSi3wqCz9fjWi4gIkGthUJHgXrZE60VEBMi1MLjoFigKH7uuKBxbLyIiCeVW\nGCy+Bi6/i46iOUQxqJgLl9+li8ciIklk9A7kjFh8DT85cDZffvgVNt78fspLi7JdIxGRSS+3zgzi\nGmbGmop2dnQn2VJERCBHw6C+UmEgInI8cjIMGuNhsOOAwkBEZCxyMgyqykooLgixo6Mn21UREZkS\ncjIMQiGjrrKUHWomEhEZk5wMA4D6irCuGYiIjFHOhkHDzLCuGYiIjFHOhkF9ZZg9h3roj0SzXRUR\nkUkvZ8OgsTKMO+zu1EVkEZFkcjYMBu810EVkEZHkcjYMBu9C1nUDEZHkcjYM6ipKAZ0ZiIiMRc6G\nQWlRAVVlJepeKiIyBjkbBhDvXqowEBFJKrfDQHchi4iMSY6HQewuZHfPdlVERCa1tISBmV1qZq+a\n2etmdnPA6yVm9pP460+Z2bx0lJtMfWWYnv4o+4/0ZaI4EZEpK+UwMLMC4BvAB4BFwEfNbNGwzf4Y\nOODuJwN3Av+Uarlj0aB7DURExiQdZwZLgNfdfau79wE/Bq4cts2VwD3x5Z8BF5mZpaHsUWmSGxGR\nsUlHGDQA24c8b42vC9zG3QeATmB20IeZ2QozazGzlra2tpQq1hi/8axVN56JiIxq0l1AdvdV7t7s\n7s3V1dUpfVZFuIhpxQXs1CQ3IiKjSkcY7ADmDnneGF8XuI2ZFQIVQHsayh6VmdFQGWZHR9dEFyUi\nMqWlIwyeARaY2YlmVgxcB6wZts0a4Pr48oeBX3qG+nvWV4Z1ZiAikkTKYRC/BnAj8AiwGVjt7pvM\n7HYzuyK+2XeA2Wb2OvBXwIjupxNFdyGLiCRXmI4Pcfe1wNph624ZstwDfCQdZR2vhsow+4/00d0X\nIVxckI0qiIhMepPuAnK66V4DEZHkcj4MdK+BiEhyOR8Gb09yozAQEUko58NgzowSCkKmGc9EREaR\n82FQWBCitrxUzUQiIqPI+TAAqK8spVVhICKSUF6EweC8BiIiEiwvwqC+Mszuzh4iUU1yIyISJC/C\noGFmmIGos/eQhqUQEQmSH2EweOOZehSJiATKrzDQdQMRkUB5EQb1CgMRkVHlRRhMLymkclqRehSJ\niCSQF2EAsaYiXTMQEQmWN2GgSW5ERBLLmzCITX/ZTYYmWBMRmVLyKgwO9w5wsGcg21UREZl08icM\nZupeAxGRRPImDNS9VEQksbwJgwbNeCYiklDehMHs6cUUF4Z0ZiAiEiClMDCzWWa2zsy2xB9nBmxz\nppn9j5ltMrONZnZtKmWOVyhkb/coEhGRY6V6ZnAzsN7dFwDr48+H6wI+6e6nA5cC/2pmlSmWOy71\nlaW6gCwiEiDVMLgSuCe+fA9w1fAN3P01d98SX94J7AWqUyx3XDTJjYhIsFTDYI6774ov7wbmjLax\nmS0BioE3Uix3XOorw+w91EvvQCQbxYuITFqFyTYws0eB2oCXVg594u5uZglv7zWzOuAHwPXuHh1l\nuxXACoCmpqZk1Tsugz2Kdnf2cMLs6Wn9bBGRqSxpGLj78kSvmdkeM6tz913xH/u9CbYrBx4CVrr7\nb5OUtwpYBdDc3JzWsSOGTnKjMBAROSrVZqI1wPXx5euBB4ZvYGbFwH3A9939ZymWl5K370LWdQMR\nkWOkGgZ3ABeb2RZgefw5ZtZsZnfHt7kGuAD4lJltiP+dmWK541JbUQooDEREhkvaTDQad28HLgpY\n3wLcEF/+IfDDVMpJl5LCAmpmlKhHkYjIMHlzB/Kget14JiIyQt6FQcNMTXIjIjJc3oVBY/zMIBrV\nJDciIoPyLgzqK8P0DURpP9KX7aqIiEwaeRcGDZrXQERkhLwLg/pKzXgmIjJc3oXB4I1n6l4qInJU\n3oVBeWkhZSWFaiYSERki78LATJPciIgMl3dhAJrkRkRkuLwMg4aZYXZ2KgxERAblZRjUV4bp6Orn\nSO9AtqsiIjIp5GUYDN5roB5FIiIxeR0GrQoDEREgX8NA9xqIiBwjL8OgZkYphSFTjyIRkbi8DIOC\nkFFbUaozAxGRuLwMA9AkNyIiQ+VtGDRWapIbEZFBeRsG9ZVhdh/sYSASzXZVRESyLm/DoGFmmEjU\n2XOoN9tVERHJurwNA81rICJyVMphYGazzGydmW2JP84cZdtyM2s1s6+nWm6qjs541pXlmoiIZF86\nzgxuBta7+wJgffx5Il8CnkxDmSk7OiSFLiKLiKQjDK4E7okv3wNcFbSRmZ0NzAF+kYYyUxYuLmDW\n9GJa1UwkIpKWMJjj7rviy7uJ/eAfw8xCwFeBzyf7MDNbYWYtZtbS1taWhuol1lAZ1o1nIiJA4Vg2\nMrNHgdqAl1YOfeLubmYesN1ngLXu3mpmo5bl7quAVQDNzc1Bn5U29ZWlvNF2ZCKLEBGZEsYUBu6+\nPNFrZrbHzOrcfZeZ1QF7AzY7F3iPmX0GKAOKzeywu492fWHCNVRO41db9uHuJAspEZFclo5mojXA\n9fHl64EHhm/g7h939yZ3n0esqej72Q4CiJ0ZdPVF6Ojqz3ZVRESyKh1hcAdwsZltAZbHn2NmzWZ2\ndxo+f8I0zhzsXqrrBiKS38bUTDQad28HLgpY3wLcELD+e8D3Ui03Hd6+8ayjmzMaKrJcGxGR7Mnb\nO5BB01+KiAzK6zCYNb2Y0qKQhqQQkbyX12FgZtRXhtnZqTAQkfyW12EAsaYinRmISL5TGFSG2aHx\niUQkz+V9GNRXhtl3uJee/ki2qyIikjV5HwaDPYp2dersQETyV96HgSa5ERFRGAy5C1mT3IhI/sr7\nMJhTXooZuogsInkt78OguDDEnBmlaiYSkbyW92EAsdFLNSSFiOQzhQHQMHOaRi4VkbymMCB2ZrCr\ns5todEInVhMRmbQUBkBjZZj+iNN2uDfbVRERyQqFAdCgSW5EJM8pDNCNZyIiCgM0yY2IiMIAmFFa\nxIzSQjUTiUjeUhjENVSGdWYgInlLYRDXUBmmVdcMRCRPpRQGZjbLzNaZ2Zb448wE2zWZ2S/MbLOZ\nvWxm81IpdyI0zNSZgYjkr1TPDG4G1rv7AmB9/HmQ7wNfcffTgCXA3hTLTbsLeh5jbfQz+K2VcOcZ\nsHF1tqskIpIxqYbBlcA98eV7gKuGb2Bmi4BCd18H4O6H3X1yjRe9cTUXvvb3NIb2YTh0bocHb1Ig\niEjeSDUM5rj7rvjybmBOwDanAB1mdq+ZPW9mXzGzghTLTa/1t1MYGTaEdX83rL89O/UREcmwwmQb\nmNmjQG3ASyuHPnF3N7OgwX0KgfcAZwFvAT8BPgV8J0F5K4AVAE1NTcmqlx6drce3XkQkxyQNA3df\nnug1M9tjZnXuvsvM6gi+FtAKbHD3rfH33A8sJUEYuPsqYBVAc3NzZkaOq2iMNQ0FrRcRyQOpNhOt\nAa6PL18PPBCwzTNApZlVx5+/D3g5xXLT66JboCh87LqicGy9iEgeSDUM7gAuNrMtwPL4c8ys2czu\nBnD3CPB5YL2ZvQgY8O8plptei6+By++id3oDUTe6wnVw+V2x9SIiecDcJ+8Y/s3Nzd7S0pKx8iJR\np/nv13HhwhruvPbMjJUrIpIuZvasuzcf7/t0B/IQBSHjvadU88RrbUQ00Y2I5BGFwTDLTq1h/5E+\nNrZ2ZLsqIiIZozAY5oIF1YQMHntl0t0kLSIyYRQGw8ycXsxZTTN57NW2bFdFRCRjFAYBli2s5sUd\nnew91JN8YxGRHKAwCLDs1BoAntDZgYjkCYVBgEV15dTMKOFxhYGI5AmFQQAzY9nCGp58rY3+SDTb\n1RERmXAKgwSWnVrNod4Bnn3zQLarIiIy4RQGCZx3chVFBcZjr6qLqYjkPoVBAjNKizhn3iwef0XX\nDUQk9ykMRrFsYQ2v7jnEDs2NLCI5TmEwimWnxkbd1t3IIpLrFAajOKm6jMaZYR7XdQMRyXEKg1EM\ndjH9zevt9PRHsl0dEZEJozBI4n2n1tDdH+HpbfuzXRURkQmjMEhi6fzZlBSG1MVURHKawiCJcHEB\n5540WxeRRSSnKQzGYNnCGn7X3sW2fUeyXRURkQmhMBiDZQtjo5jq7EBEcpXCYAyaZk/jpOrpum4g\nIjlLYTBGyxbW8NTW/XT1DWS7KiIiaZdyGJjZLDNbZ2Zb4o8zE2z3z2a2ycw2m9ldZmaplp1Jy06t\noS8S5Tevt2e7KiIiaZeOM4ObgfXuvgBYH39+DDN7N3AesBg4AzgHeG8ays6Yc+bNYnpxgZqKRCQn\npSMMrgTuiS/fA1wVsI0DpUAxUAIUAXvSUHbGFBeGOH9BFY+/shd3z3Z1RETSKh1hMMfdd8WXdwNz\nhm/g7v8DPAbsiv894u6b01B2Ri1bWMPOzh5e23M421UREUmrwrFsZGaPArUBL60c+sTd3cxGHDab\n2cnAaUBjfNU6M3uPu/8qYNsVwAqApqamsVQvYy4c7GL66l4W1s7Icm1ERNJnTGcG7r7c3c8I+HsA\n2GNmdQDxx6BG9auB37r7YXc/DDwMnJugrFXu3uzuzdXV1eP7r5ogtRWlnFZXzi91v4GI5Jh0NBOt\nAa6PL18PPBCwzVvAe82s0MyKiF08nnLNRADLFlbz7JsH6Ozuz3ZVRETSJh1hcAdwsZltAZbHn2Nm\nzWZ2d3ybnwFvAC8CLwAvuPuDaSg74953ag2RqPPrLfuyXRURkbQZ0zWD0bh7O3BRwPoW4Ib4cgT4\n01TLmgzOnFtJRbiIx17dy+8vrst2dURE0kJ3IB+nwoIQF5xSzeOvthGNqoupiOQGhcE4LFtYzb7D\nvby0szPbVRERSQuFwTi895RqzOCxV9qyXRURkbRQGIzD7LIS3tlYqaEpRCRnKAzGadnCGl5o7aD9\ncG+2qyIikjKFwTgtO7Uad3hyi5qKRGTqUxiM0xn1FVSVlfBLXTcQkRygMBinUMi4cGE1T77WxkAk\nmu3qiIikRGGQgmULa+js7mfD9o5sV0VEJCUKgxQs63uc35TcxNnfmw93ngEbV2e7SiIi45LycBR5\na+Nqpj3yOaZZd+x553Z48KbY8uJrslcvEZFx0JnBeK2/Hfq7j13X3x1bLyITZ+Pq2Jn4rZU6I08j\nnRmMV2fr8a0XkdRtXB07A+/XGXm66cxgvCoaj2+9iKQulTPy8ZxRjPcsJNPvSwOdGYzXRbcce4QC\ndFOCv2cl07JYLZGcNt4z8vGcUYz3LCTgff7gTfQPROlZ9AdEIk5/NMpAxGN/0SgDUSf8ys9pePJm\nQpHsnPUoDMZr8H/O+tuhs5W+snq+0HEVpW+ezh3N2a2ayJSwcfXb/36oaIwdYCX70atojP1IBq1P\nwN3xR28jFHBG0fNfX+Tx0AX0DkTo6Y/Q0x+lpz9C70CU65/6OyoC3rPvgZX85dMn0BeJ0jcQ++uP\nROmLROkfiPLz3i9Qx7Hvs/5u9t6/kvNXJ547/dfFXyIUSnDWozCY5BZf8/b/pGJgzsOb+fYTW7ni\nzHrefVJVdusmkinj+VEfw1F3T3+Eg939HOzpp7N7gIM9/cw4+bOc+fwtFEZ73v6oPivhR6Wf5PHv\nPk1X3wBHeiOxx74IXb0DdPVHeKO4FWxkNYqP7OLPfvhsYBVvLNkd+J5ZkTa6+gYoLgwxo7SQksIQ\nRQUhiuOPtZvaAz+vIdTO3/7+aRSGjIKCEEUho7AgRGHIKCwwGu4Nfl+mrkMqDNLoc8tP4b9e2s0X\n7n2RR/7yAkqLCrJdJZGJNYYf9YFIlANd/ew/0kf7kV72H+njwrW3UBZw1L37vr/hg2tmcbCnn76B\noDv7G7ki9Ef878LV1Fs7u2023w59gt90v4vp0X6mFxdQX1nM9JICphUXMr24gGklhRxpqWNG764R\nn9ZfVs9Df3o+pUUFsb/CECXxx9BdcwPPQkIVjdz7mfMS75PW4LMXq2jkhvfMT/y+9cd/1pNOCoM0\nKi0q4Msfegcf+/en+NdHt3DzB07NdpVExu44jvAjUaf9cC+Vv7iV4oAf9bb7V3Ltuhr2H+mjs7sf\nHzYp4NaSXYFH3XN8HxcvmkNFuIjycCHlpUWUh4soLy2MPxZRHr6I8tK/J1RUQD1w21j+2+bcPuIa\nH0VhSi65ldPrK4LfE3BdkKJwbP1oMv2+NFEYpNm7T6ri2ua5/PuvtvLBxXWc0ZDgiyYymQQc4Uce\nuInnfneAZyuWs7uzhz0He9h9sIfdnT3sPdRLJOpsLdkR+KM+O9rGabXlzJpezKzpxcwuKz66PL0E\n/1EjHBrZ/GEVjXz5Q+9I/3/fsGt8Y2rOGs97svG+NDEfHtmTSHNzs7e0tGS7Gsets6uf5Xc+Qc2M\nEh748/MoLFAPXsmgJEf40aiz51APb7Z38db+Lrbv7+IPn76cWQN7RnxUa7SK8/vuoqykkNqKUmrL\nS5lTXkptRQm15aV8+FcfINy1c2QdKubC514avY5BR8GX36X7BVJkZs+6+3F3Y9GZwQSomFbE7Vec\nzqd/9Bzf+fU2/vS9J2W7SpIvAo7w++//LPc/28pDnM9b+7to3d9N35CRdkMGnysJnrWvIdTOS7dd\nQllJgp+K6beNr2kjy0fBMlJKYWBmHwFuBU4Dlrh74GG8mV0KfA0oAO529ztSKXcq+MA76rjk9Dn8\ny7rXuOT0WuZVTc92lWQqSnKUf6innzfajrBlzyFebzvMn7SspCpybBt+UbSH8978BvfMPodTa2dw\n8aI5NM2a9vZffWWY0F2JL3omDAJI7Ud9SG88yb6UmonM7DQgCnwb+HxQGJhZAfAacDHQCjwDfNTd\nX072+VO1mWjQnoM9LP/qE5zRUMF//Mm7MAtoXBVJJKApZSBUygNN/4f7I+fx+t7D7Oo82sWyuCDE\nK0UfJUTQv2mDW0cZal3NNjkjK81E7r45Xvhomy0BXnf3rfFtfwxcCSQNg6luTnkpX7jsNP7mvhdZ\n3bKda89pynaVJFvG2FMnGnW2tR/h5Z0HueChkTc9FUZ7WLrtG3yvagnnzp/NSTVlLKgp4+SaMppm\nTUt4hJ+0e6KabfJeJq4ZNABDv52twLsSbWxmK4AVAE1NU//H87pz5vLAhh38w0ObWbawhpry0mxX\nSTItQV/8/miUV6s/wKadnWzaeZBNOw+yeddBuvoiAGxNcNNTvbXz4GfPDy4rle6JarbJa0nDwMwe\nBWoDXlrp7g+ku0LuvgpYBbFmonR/fqaFQsaXP/QOLv3ar7j1wU188+NnZ7tKkmkJBlfbe99KPtgb\nG55genEBi+rLuaZ5Lovqyzm9vhz7SWPg3ac22lG+jvBlnJKGgbsvT7GMHcDcIc8b4+vyxvzqMv7i\nogV85ZFXeWTTbi45PShbZUoYQ3OPu/O79i6ef+sAz7/VwW2drYHDA9dbO1//2FmcXl/BCbOmEQoN\nOw246Ivj76mjH385TploJnoGWGBmJxILgeuAj2Wg3EllxQXz+c+Nu/i7+19i6fzZVISLsl0lOV4J\nmnu6+iK0lC/n+bc6eH77ATZs76Cjqx+IHfHfVFRNdWRk102raOSDi+sTl6ejfMmgVHsTXQ38G1AN\ndAAb3P0SM6sn1oX0svh2lwH/Sqxr6Xfd/R/G8vlTvTfRcBtbO7jqG7/huiVN/OPVE3CXpUysO88I\nvDg7eGOWGSyoKeOsuTM5q6mSs5pmcnJNGQUv/VQ9dSRjstWb6D7gvoD1O4HLhjxfC6xNpaxcsLix\nkhveM59VT27linfWs3T+7GxXSZLoG4jy4o4Ont52gD/rbA26nktDqJ0f3fAuFjdWMKM04IxPR/gy\nBegO5Az73PJTGHj+J8z7wV/gvi92MVA/DJmXoO3/cO8Az755gJbf7efpbfvZsL2D3vjomVeHq6j1\nthEfZRWNnHdykiHL1Y4vk5zCIMPCr/ycldFvUeCawzVrAtr+++67ka898gr/d//ZRB0KQsbp9eV8\nYukJnDNvJs3zZlG19R+zOqqkyERSGGTa+tspiGRvNqN8t/dgD2UPf5Fpw7p6Fnsvn+r5AQXLruWc\nE2dxVtPMkcMwqLlHcpjCINMSzFrkCdqjJYkkXT13d/bw1LZ2fru1nae27mfrviNsLdkZeDNXdaSN\nv3r/wtHLU3OP5CiFQaYlmMN1h8/mBw9v5nPLT9EMaWMV0NwTXXMTz/5uPz/rezdPbWvnd+1dAMwo\nLWTJvFl8dEkTA083UHw44FaXDM0oJTIZKQwyLWC4AC8M8+u6T/PtJ7byy817+eo172RxY2UWKzk1\n+PrbsWHNPaGBbupavsLDoW+y5MTZfGLpCSydP5vT6sopGLypq/JWtf2LDKMwyLSAdme76BauW3wN\nta/u5eafv8jV3/xvPnPhSXz2fQsoLtTEOIPcnTfaDvPUtlhPnztH6er5/C3vP/rjP5za/kVG0Exn\nk0xndz+3PbiJe5/bwWl15Xz1I+9kUX15tqs18QLa/iNnfIRXdh/k6fiP/9Pb9tN+pA+A6hkl/Jd/\nhtkBs3MlnWVLJIeN96YzhcEkte7lPXzh3hfp7O7jpvct4M8uPImiXJ0+M2As/V4r4RZfwU96zgWg\ncWaYJSfO4l0nzmLJibOZN3sa9qLu7BUZTmGQgw4c6eOWNZt48IWdvKOhglVnbqWu5Z9zomnD3Xmz\nvYsN2zu4cO0yKvtHHuEfKJrDE5c9xjknzqKhMhz8QWOcJ0AkXygMcthDG3fxm/u+yd9Gv8U06zv6\nwmQ9Cg74gT5w0lVsaO1gw1sdbNjewQutRwdz21rycUI2jtm5RGSErIxNJJnx+4vruHTdvRQc6jv2\nhf5u+n9xKwVnfGTk8MfZsnE1vuYmbOBod8+ee2/ki33PsyZ6PiGDU+bM4JJFtZzZVMmZcyuxHzcE\n33+hrp4iGaMwmCIKDgVPAVFwaCdnfWkdZ86tfHukzDPnVh47RPZ4m1JGeV/vQIS32rtiN3G1HWHb\nvsNs23eEr+3+AvUc292zlF7+YcZ9fPSaz/OOxoqRd/aOd9x+EUkbhcFUkeBmte5ptVy2oJbn3uzg\na+u3MNjqd3JNGWfNreTqwv9m6abbCA2MPhZSNOr0R6P0R5z+gSihl37KjHV/fcz7+u67ke8+8Qb/\n0b2U1gNdRIe07FSVlTC/ejp1tAdWf0bvbs49KcEorerqKZJ1umYwVQT0uBl+zeBQTz8bWzt5/q0D\nPPdWB8+/dYAHBz5NY2jfiI/bSRWX8E36I7EAiESP/R78uvimwPftCVXzpZNXM79qOvOryzixajon\nVk+nfHDo5gRj/qu7p0hm6JpBrhvD0fOM0iLOO7nq7eGU3R1uCz5Sr6OdD5/dSFFBiKICiz8eXW5Y\nF/y+OdF9fP1jv5e4nqlMyC4iWaMwmEqOc5A0M0vYvGQVjXzx8tMTv/np4PclvairJh+RKUlhkOvG\ne6SeyhG+RvYUmXJy9JZWedvia2LXFSrmAhZ7HMu9CeN9n4hMSbqALCKSQ8Z7AVlnBiIikloYmNlH\nzGyTmUXNLDCJzGyumT1mZi/Ht/2LVMoUEZH0S/XM4CXgQ8CTo2wzAPy1uy8ClgJ/bmaLUixXRETS\nKKXeRO6+GeJdGBNvswvYFV8+ZGabgQbg5VTKFhGR9MnoNQMzmwecBTyVyXJFRGR0Sc8MzOxRoDbg\npZXu/sBYCzKzMuDnwF+6+8FRtlsBrIg/PWxmr461jCmoChg55kN+0z4Jpv0ykvbJSFXACeN5Y1q6\nlprZ48Dn3T2wH6iZFQH/CTzi7v+ScoE5wsxaxtMFLJdpnwTTfhlJ+2SkVPbJhDcTWeyCwneAzQoC\nEZHJKdWupVebWStwLvCQmT0SX19vZmvjm50H/C/gfWa2If53WUq1FhGRtEq1N9F9wH0B63cCl8WX\nfw1Mkmm4Jp1V2a7AJKR9Ekz7ZSTtk5HGvU8m9XAUIiKSGRqOQkREFAaZYGaXmtmrZva6md0c8Pqn\nzKxtyDWVG7JRz0wys++a2V4zC5z+zGLuiu+zjWY2yow6uWEM++RCM+sc8j3J+RmDxjKcTb59V8a4\nT47/u+Lu+pvAP6AAeAOYDxQDLwCLhm3zKeDr2a5rhvfLBcDvAS8leP0y4GFi15uWAk9lu86TYJ9c\nCPxntuuZ4X1SB/xefHkG8FrAv5+8+q6McZ8c93dFZwYTbwnwurtvdfc+4MfAlVmuU9a5+5PA/lE2\nuRL4vsf8Fqg0s7rM1C47xrBP8o6773L35+LLh4DB4WyGyqvvyhj3yXFTGEy8BmDo/JGtBP+P+4P4\nKe7PzGxuZqo2qY11v+Wbcx2goC0AAAF3SURBVM3sBTN72MxGmbc094wynE3efleSDPFzXN8VhcHk\n8CAwz90XA+uAe7JcH5mcngNOcPd3Av8G3J/l+mTMWIezySdJ9slxf1cUBhNvBzD0SL8xvu5t7t7u\n7r3xp3cDZ2eobpNZ0v2Wb9z9oLsfji+vBYrMrCrL1Zpw8eFsfg78yN3vDdgk774ryfbJeL4rCoOJ\n9wywwMxONLNi4DpgzdANhrVvXkGsDTDfrQE+Ge8pshTo9Nhw6HnLzGrjw7tgZkuI/fttz26tJtYY\nh7PJq+/KWPbJeL4rKd2BLMm5+4CZ3Qg8Qqxn0XfdfZOZ3Q60uPsa4CYzu4LYRED7ifUuymlm9v+I\n9Xioig9p8kWgCMDdvwWsJdZL5HWgC/jD7NQ0c8awTz4MfNrMBoBu4DqPdx3JYYPD2bxoZhvi6/4G\naIK8/a6MZZ8c93dFdyCLiIiaiURERGEgIiIoDEREBIWBiIigMBARERQGIiKCwkBERFAYiIgI8P8B\nmre+LRZPDbUAAAAASUVORK5CYII=\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          }
-        }
-      ]
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting blueqat\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/f6/73/20f9cff48caee1f69190f2e1ea93c4d7d0a745fc48defb5d3072d8337583/blueqat-0.3.13-py3-none-any.whl (50kB)\n",
+      "\u001b[K     |████████████████████████████████| 51kB 1.7MB/s \n",
+      "\u001b[?25hCollecting openfermionblueqat\n",
+      "  Downloading https://files.pythonhosted.org/packages/e0/ef/d2a4242ef5f4ff518921dfd608d7841f476e947bc23efc25bd7c3ba0042d/openfermionblueqat-0.2.2-py3-none-any.whl\n",
+      "Collecting openfermion\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/66/72/e058e3d8ececd54212bb98848e8e8227d4887fed6fe8d87f425a034add8b/openfermion-0.10.0.tar.gz (625kB)\n",
+      "\u001b[K     |████████████████████████████████| 634kB 6.6MB/s \n",
+      "\u001b[?25hRequirement already satisfied: scipy>=1.1.0 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.4.1)\n",
+      "Requirement already satisfied: numpy~=1.12 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.17.5)\n",
+      "Requirement already satisfied: h5py>=2.8 in /usr/local/lib/python3.6/dist-packages (from openfermion) (2.8.0)\n",
+      "Requirement already satisfied: future in /usr/local/lib/python3.6/dist-packages (from openfermion) (0.16.0)\n",
+      "Requirement already satisfied: jupyter in /usr/local/lib/python3.6/dist-packages (from openfermion) (1.0.0)\n",
+      "Requirement already satisfied: nbformat in /usr/local/lib/python3.6/dist-packages (from openfermion) (5.0.4)\n",
+      "Requirement already satisfied: networkx in /usr/local/lib/python3.6/dist-packages (from openfermion) (2.4)\n",
+      "Requirement already satisfied: matplotlib in /usr/local/lib/python3.6/dist-packages (from openfermion) (3.1.3)\n",
+      "Collecting pubchempy\n",
+      "  Downloading https://files.pythonhosted.org/packages/aa/fb/8de3aa9804b614dbc8dc5c16ed061d819cc360e0ddecda3dcd01c1552339/PubChemPy-1.0.4.tar.gz\n",
+      "Requirement already satisfied: six in /usr/local/lib/python3.6/dist-packages (from openfermion) (1.12.0)\n",
+      "Requirement already satisfied: qtconsole in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (4.6.0)\n",
+      "Requirement already satisfied: ipywidgets in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (7.5.1)\n",
+      "Requirement already satisfied: jupyter-console in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (5.2.0)\n",
+      "Requirement already satisfied: nbconvert in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (5.6.1)\n",
+      "Requirement already satisfied: ipykernel in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (4.6.1)\n",
+      "Requirement already satisfied: notebook in /usr/local/lib/python3.6/dist-packages (from jupyter->openfermion) (5.2.2)\n",
+      "Requirement already satisfied: traitlets>=4.1 in /usr/local/lib/python3.6/dist-packages (from nbformat->openfermion) (4.3.3)\n",
+      "Requirement already satisfied: jsonschema!=2.5.0,>=2.4 in /usr/local/lib/python3.6/dist-packages (from nbformat->openfermion) (2.6.0)\n",
+      "Requirement already satisfied: jupyter-core in /usr/local/lib/python3.6/dist-packages (from nbformat->openfermion) (4.6.2)\n",
+      "Requirement already satisfied: ipython-genutils in /usr/local/lib/python3.6/dist-packages (from nbformat->openfermion) (0.2.0)\n",
+      "Requirement already satisfied: decorator>=4.3.0 in /usr/local/lib/python3.6/dist-packages (from networkx->openfermion) (4.4.1)\n",
+      "Requirement already satisfied: pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 in /usr/local/lib/python3.6/dist-packages (from matplotlib->openfermion) (2.4.6)\n",
+      "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.6/dist-packages (from matplotlib->openfermion) (0.10.0)\n",
+      "Requirement already satisfied: kiwisolver>=1.0.1 in /usr/local/lib/python3.6/dist-packages (from matplotlib->openfermion) (1.1.0)\n",
+      "Requirement already satisfied: python-dateutil>=2.1 in /usr/local/lib/python3.6/dist-packages (from matplotlib->openfermion) (2.6.1)\n",
+      "Requirement already satisfied: pygments in /usr/local/lib/python3.6/dist-packages (from qtconsole->jupyter->openfermion) (2.1.3)\n",
+      "Requirement already satisfied: jupyter-client>=4.1 in /usr/local/lib/python3.6/dist-packages (from qtconsole->jupyter->openfermion) (5.3.4)\n",
+      "Requirement already satisfied: ipython>=4.0.0; python_version >= \"3.3\" in /usr/local/lib/python3.6/dist-packages (from ipywidgets->jupyter->openfermion) (5.5.0)\n",
+      "Requirement already satisfied: widgetsnbextension~=3.5.0 in /usr/local/lib/python3.6/dist-packages (from ipywidgets->jupyter->openfermion) (3.5.1)\n",
+      "Requirement already satisfied: prompt-toolkit<2.0.0,>=1.0.0 in /usr/local/lib/python3.6/dist-packages (from jupyter-console->jupyter->openfermion) (1.0.18)\n",
+      "Requirement already satisfied: jinja2>=2.4 in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (2.11.1)\n",
+      "Requirement already satisfied: entrypoints>=0.2.2 in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (0.3)\n",
+      "Requirement already satisfied: mistune<2,>=0.8.1 in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (0.8.4)\n",
+      "Requirement already satisfied: pandocfilters>=1.4.1 in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (1.4.2)\n",
+      "Requirement already satisfied: testpath in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (0.4.4)\n",
+      "Requirement already satisfied: defusedxml in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (0.6.0)\n",
+      "Requirement already satisfied: bleach in /usr/local/lib/python3.6/dist-packages (from nbconvert->jupyter->openfermion) (3.1.0)\n",
+      "Requirement already satisfied: tornado>=4.0 in /usr/local/lib/python3.6/dist-packages (from ipykernel->jupyter->openfermion) (4.5.3)\n",
+      "Requirement already satisfied: terminado>=0.3.3; sys_platform != \"win32\" in /usr/local/lib/python3.6/dist-packages (from notebook->jupyter->openfermion) (0.8.3)\n",
+      "Requirement already satisfied: setuptools in /usr/local/lib/python3.6/dist-packages (from kiwisolver>=1.0.1->matplotlib->openfermion) (45.1.0)\n",
+      "Requirement already satisfied: pyzmq>=13 in /usr/local/lib/python3.6/dist-packages (from jupyter-client>=4.1->qtconsole->jupyter->openfermion) (17.0.0)\n",
+      "Requirement already satisfied: pexpect; sys_platform != \"win32\" in /usr/local/lib/python3.6/dist-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets->jupyter->openfermion) (4.8.0)\n",
+      "Requirement already satisfied: simplegeneric>0.8 in /usr/local/lib/python3.6/dist-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets->jupyter->openfermion) (0.8.1)\n",
+      "Requirement already satisfied: pickleshare in /usr/local/lib/python3.6/dist-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets->jupyter->openfermion) (0.7.5)\n",
+      "Requirement already satisfied: wcwidth in /usr/local/lib/python3.6/dist-packages (from prompt-toolkit<2.0.0,>=1.0.0->jupyter-console->jupyter->openfermion) (0.1.8)\n",
+      "Requirement already satisfied: MarkupSafe>=0.23 in /usr/local/lib/python3.6/dist-packages (from jinja2>=2.4->nbconvert->jupyter->openfermion) (1.1.1)\n",
+      "Requirement already satisfied: webencodings in /usr/local/lib/python3.6/dist-packages (from bleach->nbconvert->jupyter->openfermion) (0.5.1)\n",
+      "Requirement already satisfied: ptyprocess; os_name != \"nt\" in /usr/local/lib/python3.6/dist-packages (from terminado>=0.3.3; sys_platform != \"win32\"->notebook->jupyter->openfermion) (0.6.0)\n",
+      "Building wheels for collected packages: openfermion, pubchempy\n",
+      "  Building wheel for openfermion (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+      "  Created wheel for openfermion: filename=openfermion-0.10.0-cp36-none-any.whl size=731375 sha256=a6a7b18652f246d94640f5fa1a2a85b9d71d28a0ea20032213626d14f8ed3f0f\n",
+      "  Stored in directory: /root/.cache/pip/wheels/3c/49/cd/098bb337ffcbb70021864403773043df332c065590873f1813\n",
+      "  Building wheel for pubchempy (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+      "  Created wheel for pubchempy: filename=PubChemPy-1.0.4-cp36-none-any.whl size=13825 sha256=6f935bbf877c8746569afa0d242dedb965bea20387048f6839b9f8ef47d91339\n",
+      "  Stored in directory: /root/.cache/pip/wheels/10/4d/51/6b843681a9a5aef35f0d0fbce243de46f85080036e16118752\n",
+      "Successfully built openfermion pubchempy\n",
+      "Installing collected packages: blueqat, pubchempy, openfermion, openfermionblueqat\n",
+      "Successfully installed blueqat-0.3.13 openfermion-0.10.0 openfermionblueqat-0.2.2 pubchempy-1.0.4\n"
+     ]
     }
-  ]
+   ],
+   "source": [
+    "!pip3 install blueqat openfermionblueqat openfermion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "HHLJDoRXtXta"
+   },
+   "source": [
+    "##2-3-2 Coding\n",
+    "Here we use a prepared data provided by openfermion."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 283
+    },
+    "colab_type": "code",
+    "id": "hDacEDd6tVIK",
+    "outputId": "cdb33658-119e-4c37-caf6-04d06ba417b7"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x7f34c6b411c0>]"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYMAAAD5CAYAAADFqlkBAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3de3zU1Z3/8ddnJrchkEyABHIBAUUQLYU2IlbXikJVqot2W7W39dfH9sfPthbt5dHVdVeta6uP3W2t7PbGtv7W/trdlq1asMVapN73UTQoIogIBYUQLiGQcMl95vz+mEFC8p1kkplkkvm+n49HHjPznTNzDl/Hec/3fM/5HnPOISIi/hbIdANERCTzFAYiIqIwEBERhYGIiKAwEBERFAYiIgLkpONNzOxK4CEgCPzEOfdAt+c/Dfxt/OFx4AvOudf7et/x48e7KVOmpKOJIiK+sGHDhkPOudL+vi7lMDCzIPB9YBFQC7xiZqudc292KbYL+LBz7oiZXQWsAC7o672nTJlCTU1Nqk0UEfENM3t3IK9LRzfRPGCHc26nc64d+CWwpGsB59z/OOeOxB/+CahKQ70iIpIm6QiDSmBPl8e18W2J/A3wZBrqFRGRNEnHOQPz2OZ5jQszW0AsDC5O+GZmS4GlAJMnT05D80REpC/pODKoBSZ1eVwF1HUvZGazgZ8AS5xzDYnezDm3wjlX7ZyrLi3t9zkQEREZgHSEwSvAdDObamZ5wI3A6q4FzGwy8BjwWefc22moU0RE0ijlbiLnXKeZ3QI8RWxo6cPOuS1mdnP8+R8BdwHjgB+YGUCnc6461bo9bVoJ6+6FplooroLL74LZ1w9KVSIi2cKG8yWsq6urXb+Glm5aCU8sg46WU9tyQ3DNcgWCiPiCmW0YyI/t7JqBvO7e04MAYo/X3ZuZ9oiIjBDZFQZNtf3bLiIiQLaFQXGCuWyJtouICJBtYXD5XbFzBF3lhmLbRUQkoewKg9nXwzXLacydQBSD4kk6eSwikoS0XLV0WJl9Pb868kHuf/ItNt3+EYoKcjPdIhGRYS+7jgziKktiXUV1jS19lBQREcjSMKgIKwxERPojK8OgKh4Ge48oDEREkpGVYTB+dD55wQB7G1sz3RQRkREhK8MgEDDKwwXsVTeRiEhSsjIMACqKQzpnICKSpKwNg8qSkM4ZiIgkKWvDoCIc4sCxVjoi0Uw3RURk2MvaMKgKh3AO9jfpJLKISF+yNgxOzjXQSWQRkb5lbRicnIWs8wYiIn3L2jAoLy4AdGQgIpKMrA2Dgtwg40fna3ipiEgSsjYMACo18UxEJCnZHQYlIYWBiEgSsjoMTs5Cds5luikiIsNaWsLAzK40s21mtsPMbvd43sxsefz5TWb2gXTU25fKkhCtHVEOn2gfiupEREaslMPAzILA94GrgFnAJ81sVrdiVwHT439LgR+mWm8yKjXXQEQkKek4MpgH7HDO7XTOtQO/BJZ0K7ME+JmL+RMQNrPyNNTdKy1yIyKSnHSEQSWwp8vj2vi2/pYBwMyWmlmNmdXU19en1LCq+MSzWk08ExHpVTrCwDy2dT9jm0yZ2EbnVjjnqp1z1aWlpSk1rDiUy6i8IHVa5EZEpFfpCINaYFKXx1VA3QDKpJ2ZURkOsbexebCrEhEZ0dIRBq8A081sqpnlATcCq7uVWQ38dXxU0XygyTm3Lw1196kiHNKRgYhIH3JSfQPnXKeZ3QI8BQSBh51zW8zs5vjzPwLWAIuBHUAz8LlU601WZUmIN/Y2DVV1IiIjUsphAOCcW0PsC7/rth91ue+AL6Wjrv6qDIc4fKKdlvYIobxgJpogIjLsZfUMZNBcAxGRZGR9GGiugYhI37I+DN5b5EZhICKSUNaHwYQx+QQDphXPRER6kfVhkBMMMLGoQN1EIiK9yPowAKgIF1CrMBARScgXYVAZDunIQESkF74Ig4pwiP1NrUSiWuRGRMSLL8KgsiREZ9Rx8JguSyEi4sUXYXByroFGFImIePNFGFRpFrKISK98EQYVCgMRkV75IgwK83MIj8rViCIRkQR8EQYQG16qcwYiIt58EwZa5EZEJDHfhEFs+csWYksriIhIV74Kg+NtnRxt7cx0U0REhh3/hEGJ5hqIiCTimzDQ8FIRkcR8EwaVWvFMRCQh34TBuMI88nICOjIQEfGQUhiY2VgzW2tm2+O3JR5lJpnZM2a21cy2mNmtqdQ5UIGAvTeiSERETpfqkcHtwDrn3HRgXfxxd53A15xz5wDzgS+Z2awU6x2QinCBTiCLiHhINQyWAI/E7z8CXNu9gHNun3Pu1fj9Y8BWoDLFegdEi9yIiHhLNQwmOOf2QexLHyjrrbCZTQHmAutTrHdAKsIhDh5ro60zkonqRUSGrZy+CpjZ08BEj6fu7E9FZjYaeBS4zTl3tJdyS4GlAJMnT+5PFX06OaJof1MrZ4wrTOt7i4iMZH2GgXNuYaLnzOyAmZU75/aZWTlwMEG5XGJB8Avn3GN91LcCWAFQXV2d1mtHVHZZ5EZhICJySqrdRKuBm+L3bwJWdS9gZgb8FNjqnPtuivWl5L1ZyDpvICJymlTD4AFgkZltBxbFH2NmFWa2Jl7mIuCzwGVmtjH+tzjFegdkYnEBoDAQEemuz26i3jjnGoDLPbbXAYvj918ELJV60iU/J0jZmHyNKBIR6cY3M5BPqtDEMxGRHnwXBpUlWuRGRKQ7/4VB/MggGtUiNyIiJ/kyDNo7ozScaM90U0REhg1fhgFoRJGISFe+C4OKsFY8ExHpzndhcHLimYaXioic4rswKCrIYXR+jrqJRES68F0YmGmRGxGR7nwXBqBFbkREuvNlGFSWhKhrUhiIiJzkyzCoCIdobO7gRFtnppsiIjIs+DIMTs410IgiEZEYX4dBrcJARATwaxhoroGIyGl8GQZlYwrICZhGFImIxPkyDIIBY2JxgY4MRETifBkGoEVuRES68m0YVIW1yI2IyEm+DYOKcIj9R1vpjEQz3RQRkYzzbRhUloSIRB0HjrVluikiIhnn2zDQugYiIqekFAZmNtbM1prZ9vhtSS9lg2b2mpn9NpU60+XUimfNGW6JiEjmpXpkcDuwzjk3HVgXf5zIrcDWFOtLm4pwAYBOIouIkHoYLAEeid9/BLjWq5CZVQEfBX6SYn1pMyovh7GFedSqm0hEJOUwmOCc2wcQvy1LUO57wDeAPofumNlSM6sxs5r6+voUm9e7ynBIE89ERICcvgqY2dPARI+n7kymAjO7GjjonNtgZpf2Vd45twJYAVBdXe2SqWOgKsIF/Ln+xGBWISIyIvQZBs65hYmeM7MDZlbunNtnZuXAQY9iFwF/aWaLgQKgyMx+7pz7zIBbnSaV4VG8sP0QzjnMLNPNERHJmFS7iVYDN8Xv3wSs6l7AOXeHc67KOTcFuBH443AIAogdGTS3R2hs7sh0U0REMirVMHgAWGRm24FF8ceYWYWZrUm1cYOtquTk8FKdNxARf+uzm6g3zrkG4HKP7XXAYo/tzwLPplJnOr038ayxhfMqizPcGhGRzPHtDGTQ8pciIif5OgzGFuZRkBvQJSlExPd8HQZmRkU4RF2TwkBE/M3XYQCxriIdGYiI3ykMwiH26vpEIuJzvg+DinCIQ8fbaO2IZLopIiIZ4/swODmiaF+Tjg5ExL98HwZa5EZERGHQZRayFrkREf/yfRhMKCrADJ1EFhFf830Y5OUEmDCmQN1EIuJrvg8DiF29VJekEBE/UxgAlSWjdOVSEfE1hQGxI4N9TS1Eo4O6sJqIyLClMACqwiE6Io76422ZboqISEYoDIBKLXIjIj6nMEATz0REFAZokRsREYUBMKYglzEFOeomEhHfUhjEVYZDOjIQEd9SGMRVhkPU6pyBiPhUSmFgZmPNbK2ZbY/fliQoFzazX5vZW2a21cwuTKXewVBZoiMDEfGvVI8MbgfWOeemA+vij708BPzeOTcTeD+wNcV60+6S1mdYE/0i7p4wPHgebFqZ6SaJiAyZVMNgCfBI/P4jwLXdC5hZEXAJ8FMA51y7c64xxXrTa9NKLn37PqoChzAcNO2BJ5YpEETEN1INgwnOuX0A8dsyjzLTgHrg/5rZa2b2EzMrTLHe9Fp3LzmRbpew7miBdfdmpj0iIkOszzAws6fNbLPH35Ik68gBPgD80Dk3FzhB4u4kzGypmdWYWU19fX2SVaSoqbZ/20VEskxOXwWccwsTPWdmB8ys3Dm3z8zKgYMexWqBWufc+vjjX9NLGDjnVgArAKqrq4fmynHFVbGuIa/tIiI+kGo30Wrgpvj9m4BV3Qs45/YDe8xsRnzT5cCbKdabXpffBbmh07flhmLbRUR8INUweABYZGbbgUXxx5hZhZmt6VLuy8AvzGwTMAf4dor1ptfs6+Ga5bQVVhJ1RnOoHK5ZHtsuIuID5tzwvYZ/dXW1q6mpGbL6IlFH9X1ruXRGGQ/eMGfI6hURSRcz2+Ccq+7v6zQDuYtgwPjw2aU893Y9ES10IyI+ojDoZsHMMg6faGdT7fCaCiEiMpgUBt1cMr2UgMEzb3kNjBIRyU4Kg25KCvOYO7mEZ7YN0RwHEZFhQGHgYcGMUt7Y28TBY619FxYRyQIKAw8LZsauqvGcjg5ExCcUBh5mlRdRNiafZxUGIuITCgMPZsaCGWU8/3Y9HZFoppsjIjLoFAYJLJhZyrG2Tja8eyTTTRERGXQKgwQuOms8uUHjmW0aYioi2U9hkMCYglzOnzKWZ9/SeQMRyX4Kg14smFHGtgPH2Ku1kUUkyykMerFgZimg2cgikv0UBr04s3Q0VSUhntV5AxHJcgqDXpwcYvrSjgZaOyKZbo6IyKBRGPThsplltHREeHnX4Uw3RURk0CgM+jB/2jjycwIaYioiWU1h0IdQXpALzxynk8giktUUBklYMKOMdxqa2XXoRKabIiIyKBQGSVgwI3YVUx0diEi2UhgkYfK4UZxZWqjzBiKStRQGSVowo4z1Ow/T3N6Z6aaIiKRdSmFgZmPNbK2ZbY/fliQo9xUz22Jmm83sv8ysIJV6M2HBzDLaI1Fe2tGQ6aaIiKRdqkcGtwPrnHPTgXXxx6cxs0pgGVDtnDsPCAI3pljvkDt/ylgK84LqKhKRrJRqGCwBHonffwS4NkG5HCBkZjnAKKAuxXqHXF5OgIunj+fZtw7inMt0c0RE0irVMJjgnNsHEL8t617AObcX+BdgN7APaHLO/SHFejNiwYwy6ppaefvA8Uw3RUQkrfoMAzN7Ot7X3/1vSTIVxM8jLAGmAhVAoZl9ppfyS82sxsxq6uuH11oCl54cYqquIhHJMn2GgXNuoXPuPI+/VcABMysHiN96fUsuBHY55+qdcx3AY8CHeqlvhXOu2jlXXVpaOrB/1SCZWFzAOeVF/FHzDUQky6TaTbQauCl+/yZglUeZ3cB8MxtlZgZcDmxNsd6MWTCjlA3vHqGppSPTTRERSZtUw+ABYJGZbQcWxR9jZhVmtgbAObce+DXwKvBGvM4VKdabMZfNLCMSdby4/VCmmyIikjY5qbzYOddA7Jd+9+11wOIuj+8G7k6lruFizqQwxaFcntl2kI/OLs90c0RE0kIzkPspJxjgkrNLeXZbPdGohpiKSHZQGAzAghmlHDrexua6pkw3RUQkLRQGA/Dhs0sxg2feGl5DX0VEBkphMADjRufz/qqw5huISNZQGAzQghllvF7bSMPxtkw3RUQkZQqDAVowsxTn4Pnt6ioSkZFPYTBA51UUM350Pn/UeQMRyQIKgwEKBIxLZ5Ty/Nv1dEaimW6OiEhKFAYpWDCjjKaWDjbuacx0U0REUqIwSMGC9md5KX8ZH/yPafDgebBpZaabJCIyICldjsLXNq1k1FNfYZS1xB437YEnlsXuz74+c+0SERkAHRkM1Lp7oaPl9G0dLbHtIiIjjMJgoJpq+7ddRGQYUxgMVHFV/7aLyMizaWXsfOA94f6dFxzq16WBzhkM1OV3xc4RdOkqaiEf9xd3MiqDzRIZMTatjHWrNtXGfkRdfldy59uG6nWbVp7+/3iy5wU9XueeWEZHZ5TWWX9FJOLoiEbpjLjYXzRKZ9QReutRKp+/nUAkM+chzbnhexnm6upqV1NTk+lmJNblw9U+uoJvNF5LwdwbeeCvZme6ZSLDW/cvTIDcEFyzvH9ftEm8zjlH+2u/Im/NbVjnqddFgiG2zbuP3ZVX09YZobUjQmtHlNaOCG2dUW5afzXF7ft7vN+hYBm3lf+c9kiU9s7YX0ckSnskSkdnlEfbllJOz8WvaqPjubh9ecJ/2ot5y6gKeCyaVTwJvrI58T7pxsw2OOeqk35BnI4MUjH7+vc+gHnAhCe38uPndvKXcyr40JnjM9s2kaEykF/qvQ3AiL+2tSPC0ZYOjrZ20NTSydHWDi548i5GebyuYfXf89WaKTS3d3KiLRK7bY/Q3NZJc0eEF3LvpCpw+uuCkRaKXrqfm9u9F6m6JX8/WM/tYyP1NLd3kpcTYExBDvk5AXKDAfLitxO3NHi+X2Wggb//6DnkBIxgMEBuwMgJBsgJGDlBo/Ix79cN1XlIhUEafWXh2fx+837ueOwNnrrtEgpyg5luksjgSqIrpTMS5UhzB4dPtNNwoo3DJ9r5aFOt1/cs0aZa5t33NEdbO2jv7Dmzf2f+Ps8v6JLOgzS2dFCYF6QinEdhfpBReTkU5gUZlZ9D5UuJv6B/t+xiCnKDsb+cAPnx28DySbF/TzeB4ioe++JFifdJbZXn66y4is//xbTEr1vn/bqhOg+pMEijgtwg93/sfXzq39fzvae3c/tVMzPdJJHk9eMXfiTqaDjeRvgP95Dn8Uu9/jd3csPaMg6faKeppYPuvdFz8sZ5dokcySlj0awJFIdyKQrlUFSQS1Eol6KCHIpCuURWVhI4vrfH6wLFVaz6Ui9f0JsTf0GfW1Hs/RqP84LkhmLbezPUr0sThUGafejM8dxQPYl/f2EnV88u57zKBB80kcEykG4bj1/4kVXLePWdI2woXsj+plYOHG1l/9FW9je1cvBYG5GoY2f+Xs9f6uOi9ZwzsYixhXmMLcxj3Oi8U/cL8yna/Y+4tV/Fun3xjbvmPu6f/b7E7fzIPUP3RXtyn/V3Xw7169JEJ5AHQVNzBwsffI6yMfms+tJF5AQ1gleGSBInWKNRx4Fjrbzb0Mzuw83sOdzM516+hrGdB3q83cmTnqPzc5hYXMDEogImFBUwsTifiUUFfPyFqwg11/VsRzInPYf7aKIRaqAnkBUGg+TJN/bxhV+8yh1XzeT/fPjMTDdH/OLB8zy7QxpzJ3Bbxc/ZfbiZ2sMttHe50m7AYEf+pwnQ87vAYZy44xCj8xN0Igx0VJAMmoyMJjKzTwD3AOcA85xznt/cZnYl8BAQBH7inHsglXpHgqveV84V507gu2vf5opzJzJlfGGmmyQjUR+/Zo+1dvDn+hNsP3CMHfXHuT3BidmijoMcOt7GzIljWDRrApPHjnrvryIcIrA8cZ96wiCAjHdtSPqkdGRgZucAUeDHwNe9wsDMgsDbwCKgFngF+KRz7s2+3n8kHxkAHDjaysLvPMd5lcX85/++ADOv/01FEvD41d0ZKGDV5L/lN5GL2HHwOPuaWt97Li8Y4IW8LzPBeSy41Fe3jX7hZ42MHBk457bGK++t2Dxgh3NuZ7zsL4ElQJ9hMNJNKCrgjsXn8HePv8HKmj3ccP7kTDdJMiXJ/upo1LGr4QRv1h3lkt/9A8XdRurkRFuZv+v7/Mf4eVw4bRxnlo1metloziobzeSxo8jZ8u2BnWDVL3zfG4rRRJVA1+PPWuCCRIXNbCmwFGDy5JH/5Xnj+ZNYtXEv3/rdVhbMKKOsqCDTTZKhlmAsfkc0yrbSq9hS18SWuqNsqTvK1n1HaW6PALAzwaSnCmvgiS9f7F1XKl/qXSZRiv/0GQZm9jQw0eOpO51zq5Kow+uwIWHflHNuBbACYt1ESbz/sBYIGPd/7H1c+dAL3PPEFn7w6Q9mukky1BLMtj34+J1c3TYGgMK8ILMqiri+ehKzKoo4t6II+1WV5+xT62sSkr7UZQD6DAPn3MIU66gFJnV5XAV4jEXLXtNKR3Pr5dP556e28dSW/Vxxrle2yoiQRHePc453Gpp5bfcRXtvdyDebaj0vD1xhDfzbp+ZybkUxZ4wdRSDQ7XfT5XdndBKS+MtQdBO9Akw3s6nAXuBG4FNDUO+wsvSSafx20z7+4TebmT9tHMWh3Ew3SforQXdPc3uEmqKFvLa7kdf2HGHjnkYamzuA2C/+ZbmllEYO9ng7K67i6tkVietTP74MoVRHE10H/CtQCjQCG51zV5hZBbEhpIvj5RYD3yM2tPRh59y3knn/kT6aqLtNtY1c+/2XuHHeZL59XS+zLGV4SjCG/+TELDOYXjaauZNKmDs5zNzJJZxVNprg5v/WSB0ZMpkaTfQ48LjH9jpgcZfHa4A1qdSVDWZXhfn8X0xj/4s/o23Hb8g/sU+/9oa59s4ob+xt5OVdR7g5wRj+ykADv/j8BcyuKmZMgccRn37hywigaxMNsa9PfJ1o3k/JP9EW2zDEC1hIXIK+/+NtnWx49wg17xzm5V2H2binkbb41TOvC41noscYfiuu4qKz+rhkuU7qyjCnMBhiec/dB7SdvrHbddxlkHn0/bc/fgsPPfUWPzz8QaIOggHj3IoiPjP/DM6fUkL1lLGM3znAMfwiI4DCYKglWqhiiBaw8LuDR1sZ/eTdPRZIyXNt/K/W/0dwwQ2cP3UscyeX9LwMg7p7JIspDIZasfc1YNoKK8jPQHNGvD6Geu5vamX9rgb+tLOB9TsPs/PQCXbm13nOfimN1PPVj8zovT5190iWUhgMNY/rqreQzx2NS5jw5Fa+svBsrZCWLI/unujqZWx45zC/bv8Q63c18E5DMwBjCnKYN2Usn5w3mc6XK8nzWCBlqFaUEhmOFAZDzaur4ZI7Cb17Lj9+bid/3HqQ71z/fmZXhTPbzhHArbv39MVRgEBnC+U1/8yTgR8wb+o4PjP/DOZPG8c55UUET07qCt+jvn+RbrSewTDy7LaD3P7oG9Qfb+OLl57Jly+bTl6OTxbGSXJm75/rj7N+V2ykz4NvLUh4Df7oXUdOffkPsD6RkUiL22SJppYOvvnEFh57dS/nlBfxnU+8n1kVRZlu1uBKcPnk6NXL2Vp6BS/Hv/xf3nWYhhPtAJSOyef37ouM81idK6lVtkSylMIgy6x98wB3PPYGTS3tLLtsOjdfeia52bp8ZoKZvXWM50OtywGoKgkxb+pYLpg6lnlTxzFl3CjsDc3sFekuIzOQZfAsmjWB6jNKuGv1Fr6z9m3+8OYBVszZSXnNP2VF14Zzjncbmtm4p5ElCWb2ltPA926Yw/lTx1IZDvUsoKGeImmjMBjGSgrz+NdPzuXKcyfy0uM/oPjpH4HFukmG9cxlj/74I2dey8baRjbubmTjnkZerz11Mbfz88dRaYd6vI0VV3Ht3Mre69JQT5G0UDfRCBH5zrkEj/WcmNYxupLgV7f0vPxxpmxaiVu9DOs81XXTSj7faP8bVkcvJmBw9oQxvL8qzJzJYeZMCnP2gScJ/u5WdfeIpIG6ibJc8JjHuHggeKyOuf+4ljmTwu9dKXPOpPDpl8ge6MiZXl7X1hlhd0NzbBJX/Ql2HTrOrkMneGj/HVRw+nDPAtr41pjH+eT1X+d9VcU9Z/aW3wABU3ePSAYpDEaKBDOXW0ZNZPH0ibz6biMPrdvOyQO9s8pGM3dSmOty/of5W75JoPP0a/ADp33ZRqOOjmiUjoijozNKYPN/M2bt1057Xfvjt/Dwc3/mP1vmU3ukmWiXg8rxo/OZVlpIOQ2ezR/Ttp8LzxyX+N+n7h6RjFIYjBQeM5fJDVF41b3cP3s2AMdaO9hU28Rru4/w6u5Gnt56gFs7/4VAoOeSi3WP3cEVjxXTEYkFQCR6enfhi3l3URzoef2e6478lM1nXcG1cyqYVjqaqeMLmVpaSNHJSzc/6B1amt0rMrwpDEaKJEbOjCnI5aKzxr93OWXnHHzT+5d6OQ18/INV5AYD5AYtfnvqfuVa79dNiB7i3z71gcTtTBBamt0rMrwpDEaSfnalmFnC7iUrruLua85N/OKXB/gLX8M9RUYkhUG2G+gv9VR+4av/X2TEydIprfKe2dfHhmgWTwIsdpvMkM2Bvk5ERiTNMxARySIDnWegIwMREUktDMzsE2a2xcyiZuaZRGY2ycyeMbOt8bK3plKniIikX6pHBpuBjwHP91KmE/iac+4cYD7wJTOblWK9IiKSRimNJnLObYX4EMbEZfYB++L3j5nZVqASeDOVukVEJH2G9JyBmU0B5gLrh7JeERHpXZ9HBmb2NDDR46k7nXOrkq3IzEYDjwK3OeeO9lJuKbA0/vC4mW1Lto4RaDzQ89rN/qZ94k37pSftk57GA2cM5IVpGVpqZs8CX3fOeY4DNbNc4LfAU86576ZcYZYws5qBDAHLZton3rRfetI+6SmVfTLo3UQWO6HwU2CrgkBEZHhKdWjpdWZWC1wI/M7MnopvrzCzNfFiFwGfBS4zs43xv8UptVpERNIq1dFEjwOPe2yvAxbH778InkvcCqzIdAOGIe0Tb9ovPWmf9DTgfTKsL0chIiJDQ5ejEBERhcFQMLMrzWybme0ws9s9nr/UzJq6nFPJ+pVgzOxhMztoZpsTPG9mtjy+zzaZWS8r6mSHJPaJHz8nfV7Oxm+flST3Sf8/K845/Q3iHxAE/gxMA/KA14FZ3cpcCvw2020d4v1yCfABYHOC5xcDTxI73zQfWJ/pNg+DfeLHz0k58IH4/THA2x7///jqs5LkPun3Z0VHBoNvHrDDObfTOdcO/BJYkuE2ZZxz7nngcC9FlgA/czF/AsJmVj40rcuMJPaJ7zjn9jnnXo3fPwacvJxNV776rCS5T/pNYTD4KoGu60fW4v0f7kIze93MnjSzXtaj9I1k95vf+PZz0svlbHz7WenjEj/9+qxo2cvB5zWstvsQrleBM5xzx+NzMH4DTB/0lg1vyew3v/Ht56SPy9n48rPSxz7p92dFRwaDrxaY1OVxFUS9ITcAAAELSURBVFDXtYBz7qhz7nj8/hog18zGD10Th6U+95vf+PVzEr+czaPAL5xzj3kU8d1npa99MpDPisJg8L0CTDezqWaWB9wIrO5awMwmxi/bgZnNI/bfpWHIWzq8rAb+Oj5SZD7Q5GKXQ/ctP35Okrycja8+K8nsk4F8VtRNNMicc51mdgvwFLGRRQ8757aY2c3x538EfBz4gpl1Ai3AjS4+JCBbmdl/ERvxMD5+SZO7gVx4b5+sITZKZAfQDHwuMy0dOknsE999Tjh1OZs3zGxjfNvfAZPBt5+VZPZJvz8rmoEsIiLqJhIREYWBiIigMBARERQGIiKCwkBERFAYiIgICgMREUFhICIiwP8HeHfKjstTzkAAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from blueqat import *\n",
+    "from openfermion import *\n",
+    "from openfermionblueqat import*\n",
+    "import numpy as np\n",
+    "\n",
+    "def get_molecule(bond_len):\n",
+    "  geometry = [('H',(0.,0.,0.)),('H',(0.,0.,bond_len))]\n",
+    "\n",
+    "  description = format(bond_len)\n",
+    "  molecule = MolecularData(geometry, \"sto-3g\",1,description=description)\n",
+    "\n",
+    "  molecule.load()\n",
+    "  return molecule\n",
+    "\n",
+    "x = [];e=[];fullci=[]\n",
+    "for bond_len in np.arange(0.2,2.5,0.1):\n",
+    "  m = get_molecule(\"{:.2}\".format(bond_len))\n",
+    "  h = bravyi_kitaev(get_fermion_operator(m.get_molecular_hamiltonian()))\n",
+    "  runner = vqe.Vqe(UCCAnsatz(h,6,Circuit().x[0]))\n",
+    "  result = runner.run()\n",
+    "  x.append(bond_len)\n",
+    "  e.append(runner.ansatz.get_energy_sparse(result.circuit))\n",
+    "  fullci.append(m.fci_energy)\n",
+    "\n",
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "plt.plot(x,fullci)\n",
+    "plt.plot(x,e,\"o\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "XC1xaDwbtcxb"
+   },
+   "source": [
+    "We got a result on the H2 problem."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "3vw6h4eytfK2"
+   },
+   "source": [
+    "##2-3-3 Checking inside the coding\n",
+    "Using MoluculearData function on OpenFermion, we can use prepare data of Sto-3g on H2 molecule."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "U2xwZyAItaMu"
+   },
+   "outputs": [],
+   "source": [
+    "def get_molecule(bond_len):\n",
+    "  geometry = [('H',(0.,0.,0.)),('H',(0.,0.,bond_len))]\n",
+    "\n",
+    "  description = format(bond_len)\n",
+    "  molecule = MolecularData(geometry, \"sto-3g\",1,description=description)\n",
+    "\n",
+    "  molecule.load()\n",
+    "  return molecule"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "jy8xNG4Etk2S"
+   },
+   "source": [
+    "Here we select 0.4 as the bond length between atoms. We get a formulation on second quantization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 646
+    },
+    "colab_type": "code",
+    "id": "TO1lSYvbtikE",
+    "outputId": "51191d25-cec4-4d64-a0c5-99ddeebe83d8"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "() 1.322943021475\n",
+       "((0, 1), (0, 0)) -1.4820918858979102\n",
+       "((1, 1), (1, 0)) -1.4820918858979102\n",
+       "((2, 1), (2, 0)) -0.1187350527865787\n",
+       "((3, 1), (3, 0)) -0.1187350527865787\n",
+       "((0, 1), (0, 1), (0, 0), (0, 0)) 0.36843967630348756\n",
+       "((0, 1), (0, 1), (2, 0), (2, 0)) 0.08225771204699692\n",
+       "((0, 1), (1, 1), (1, 0), (0, 0)) 0.36843967630348756\n",
+       "((0, 1), (1, 1), (3, 0), (2, 0)) 0.08225771204699692\n",
+       "((0, 1), (2, 1), (0, 0), (2, 0)) 0.082257712046997\n",
+       "((0, 1), (2, 1), (2, 0), (0, 0)) 0.3626667179796745\n",
+       "((0, 1), (3, 1), (1, 0), (2, 0)) 0.082257712046997\n",
+       "((0, 1), (3, 1), (3, 0), (0, 0)) 0.3626667179796745\n",
+       "((1, 1), (0, 1), (0, 0), (1, 0)) 0.36843967630348756\n",
+       "((1, 1), (0, 1), (2, 0), (3, 0)) 0.08225771204699692\n",
+       "((1, 1), (1, 1), (1, 0), (1, 0)) 0.36843967630348756\n",
+       "((1, 1), (1, 1), (3, 0), (3, 0)) 0.08225771204699692\n",
+       "((1, 1), (2, 1), (0, 0), (3, 0)) 0.082257712046997\n",
+       "((1, 1), (2, 1), (2, 0), (1, 0)) 0.3626667179796745\n",
+       "((1, 1), (3, 1), (1, 0), (3, 0)) 0.082257712046997\n",
+       "((1, 1), (3, 1), (3, 0), (1, 0)) 0.3626667179796745\n",
+       "((2, 1), (0, 1), (0, 0), (2, 0)) 0.36266671797967454\n",
+       "((2, 1), (0, 1), (2, 0), (0, 0)) 0.08225771204699726\n",
+       "((2, 1), (1, 1), (1, 0), (2, 0)) 0.36266671797967454\n",
+       "((2, 1), (1, 1), (3, 0), (0, 0)) 0.08225771204699726\n",
+       "((2, 1), (2, 1), (0, 0), (0, 0)) 0.08225771204699728\n",
+       "((2, 1), (2, 1), (2, 0), (2, 0)) 0.38272169831413727\n",
+       "((2, 1), (3, 1), (1, 0), (0, 0)) 0.08225771204699728\n",
+       "((2, 1), (3, 1), (3, 0), (2, 0)) 0.38272169831413727\n",
+       "((3, 1), (0, 1), (0, 0), (3, 0)) 0.36266671797967454\n",
+       "((3, 1), (0, 1), (2, 0), (1, 0)) 0.08225771204699726\n",
+       "((3, 1), (1, 1), (1, 0), (3, 0)) 0.36266671797967454\n",
+       "((3, 1), (1, 1), (3, 0), (1, 0)) 0.08225771204699726\n",
+       "((3, 1), (2, 1), (0, 0), (1, 0)) 0.08225771204699728\n",
+       "((3, 1), (2, 1), (2, 0), (3, 0)) 0.38272169831413727\n",
+       "((3, 1), (3, 1), (1, 0), (1, 0)) 0.08225771204699728\n",
+       "((3, 1), (3, 1), (3, 0), (3, 0)) 0.38272169831413727"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "m = get_molecule(0.4)\n",
+    "m.get_molecular_hamiltonian()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "MCcUSNvltukv"
+   },
+   "source": [
+    "This is not a hamiltonian with pauli operator, so we need a transformation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "sP1KphQktw8Z"
+   },
+   "source": [
+    "##2-3-4 Transformation\n",
+    "\n",
+    "Bravi-Kitaev transformation or Jordan–Wigner transformation are famous. Now we use the former BK transformation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 272
+    },
+    "colab_type": "code",
+    "id": "3B3loOfutn2j",
+    "outputId": "99f7f869-64b7-4297-ac30-52d52b4147ff"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(0.7407724940116754+0j) [] +\n",
+      "(0.041128856023498556+0j) [X0 Z1 X2] +\n",
+      "(0.041128856023498556+0j) [X0 Z1 X2 Z3] +\n",
+      "(0.041128856023498556+0j) [Y0 Z1 Y2] +\n",
+      "(0.041128856023498556+0j) [Y0 Z1 Y2 Z3] +\n",
+      "(0.23528824284103544+0j) [Z0] +\n",
+      "(0.23528824284103542+0j) [Z0 Z1] +\n",
+      "(0.18133335898983727+0j) [Z0 Z1 Z2] +\n",
+      "(0.18133335898983727+0j) [Z0 Z1 Z2 Z3] +\n",
+      "(0.14020450296633868+0j) [Z0 Z2] +\n",
+      "(0.14020450296633868+0j) [Z0 Z2 Z3] +\n",
+      "(0.18421983815174378+0j) [Z1] +\n",
+      "(-0.45353118471995524+0j) [Z1 Z2 Z3] +\n",
+      "(0.19136084915706864+0j) [Z1 Z3] +\n",
+      "(-0.45353118471995524+0j) [Z2]\n"
+     ]
+    }
+   ],
+   "source": [
+    "h = bravyi_kitaev(get_fermion_operator(m.get_molecular_hamiltonian()))\n",
+    "print(h)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "xWER997LuB9V"
+   },
+   "source": [
+    "Now we got a hamiltonian with pauli operator, now we can solve it with VQE. To solve this efficiently we use UCC theory on ansatz. By using a prepared UCCansatz in blueqat we get,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 714
+    },
+    "colab_type": "code",
+    "id": "97RcOB7Rt4_7",
+    "outputId": "730c7fd9-0eed-4349-edd0-24aae9f26ba5"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "params: [0.70164565 0.11001547] val: -0.5797580164453399\n",
+      "params: [0.70164565 0.11001547] val: -0.5797580164453399\n",
+      "params: [1.70164565 0.11001547] val: 0.6866759852375767\n",
+      "params: [-0.91638835  0.11001547] val: -0.290721644465588\n",
+      "params: [0.70164565 0.11001547] val: -0.5797580164453399\n",
+      "params: [0.08361167 0.11001547] val: -0.8940999003449719\n",
+      "params: [0.08361167 0.11001547] val: -0.8940999003449719\n",
+      "params: [0.08361167 1.11001547] val: -0.19463031566496408\n",
+      "params: [ 0.08361167 -1.50801853] val: 0.3583855877329869\n",
+      "params: [0.08361167 0.11001547] val: -0.8940999003449719\n",
+      "params: [ 0.08361167 -0.50801851] val: -0.709320072764051\n",
+      "params: [0.08361167 0.49198147] val: -0.7381515159460594\n",
+      "params: [0.08361167 0.01236402] val: -0.8991130288137822\n",
+      "params: [-0.5344223  -0.08528742] val: -0.7059118687677622\n",
+      "params: [0.08361167 0.01236402] val: -0.8991130288137822\n",
+      "params: [-0.5344223  -0.08528742] val: -0.7059118687677622\n",
+      "params: [1.08361166 0.17036738] val: -0.24407758400920698\n",
+      "params: [0.08361167 0.01236402] val: -0.8991130288137822\n",
+      "params: [0.46557767 0.07271593] val: -0.7505506656373621\n",
+      "params: [-0.15245629 -0.02493551] val: -0.886924766960334\n",
+      "params: [ 0.00179119 -0.00056389] val: -0.9043588023121355\n",
+      "params: [ 0.00179119 -0.00056389] val: -0.9043588023121355\n",
+      "params: [0.00179119 0.99943611] val: -0.23407346885577465\n",
+      "params: [ 0.00179119 -1.61859789] val: 0.6139694789345231\n",
+      "params: [ 0.00179119 -0.00056389] val: -0.9043588023121355\n",
+      "params: [ 0.00179119 -0.61859786] val: -0.6333409811348125\n",
+      "params: [0.00179119 0.38140211] val: -0.799593361886041\n",
+      "params: [ 0.00179119 -0.00197791] val: -0.9043561565053925\n",
+      "params: [1.79119297e-03 2.79368516e-05] val: -0.9043590357751042\n",
+      "params: [0.00179119 0.14569991] val: -0.8889379138723625\n",
+      "params: [0.00179119 0.00298706] val: -0.9043524711418675\n",
+      "params: [1.79119297e-03 2.79368516e-05] val: -0.9043590357751042\n",
+      "params: [-0.08002929 -0.01289997] val: -0.8995345185001391\n",
+      "params: [0.13417951 0.02094574] val: -0.8908571280247335\n",
+      "params: [1.79119297e-03 2.79368516e-05] val: -0.9043590357751042\n",
+      "params: [0.05235903 0.00801782] val: -0.9022979207686519\n",
+      "params: [-0.02946145 -0.00491009] val: -0.9037050083744771\n",
+      "params: [ 4.36428587e-05 -2.48181936e-04] val: -0.9043613509785144\n",
+      "params: [-0.00869411 -0.00162878] val: -0.9043038145362967\n"
+     ]
+    }
+   ],
+   "source": [
+    "runner = vqe.Vqe(UCCAnsatz(h,2,Circuit().x[0]))\n",
+    "result = runner.run(verbose = True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "pogBuf8HuG9y"
+   },
+   "source": [
+    "After the optimizing process we get the minimized result. This time we use UCC ansatz with Hamiltonian."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "colab_type": "code",
+    "id": "7aogyg6YuD6S",
+    "outputId": "48520c01-5ad1-4d42-fc6c-ccf395d1df9b"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "-0.9043613509785144"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "runner.ansatz.get_energy_sparse(result.circuit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "gFgZVsk6uMXf"
+   },
+   "source": [
+    "Again this is the whole code for H2 UCCansatz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 283
+    },
+    "colab_type": "code",
+    "id": "uP2XQ8j3uJnr",
+    "outputId": "83f553f0-957b-4660-b275-4e56a1ef0ab2"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x7f34c9e17850>]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYMAAAD5CAYAAADFqlkBAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3deZxcZZ3v8c+vqrfK0kuS7qSXhCQYAgEiaINBGCQSFCIY3BBXrq+ZyXXBqKOvGRAvIOPCzFxl4I6oGfVeRp3RjIAECSJEFsWXYLMYiAESE0k6a6eT7iy9V/3uH1Uhne6qruqu6q7uOt/369Wvqjp1Tj1PDsX51nnOc57H3B0REQm2UL4rICIi+acwEBERhYGIiCgMREQEhYGIiKAwEBERoCgXH2JmlwK3A2Hge+5+64D3PwT8Q+LlEeAT7v7HdJ87Y8YMnzt3bi6qKCISCM8888x+d68e7nZZh4GZhYFvAZcAzcAfzGytu/+p32rbgLe4+0EzuwxYDbwp3WfPnTuXpqambKsoIhIYZvbqSLbLRTPRucAWd9/q7j3AT4AV/Vdw99+5+8HEy98DDTkoV0REciQXYVAP7Oj3ujmxLJW/Bh7MQbkiIpIjubhmYEmWJR3jwsyWEg+DC1J+mNlKYCXAnDlzclA9ERFJJxdnBs3A7H6vG4BdA1cys8XA94AV7t6a6sPcfbW7N7p7Y3X1sK+BiIjICOQiDP4ALDCzeWZWAlwNrO2/gpnNAe4BPuLur+SgTBERyaGsm4ncvc/MrgUeIt619AfuvtHMPp54/zvAjcB04E4zA+hz98Zsy05qwxpYfwu0N0NFA1x8Iyy+alSKEhEpFDaeh7BubGz0YXUt3bAG7l8FvZ3HlxVH4Io7FAgiEghm9sxIfmwX1h3I6285MQgg/nr9Lfmpj4jIBFFYYdDePLzlIiICFFoYVKS4ly3VchERAQotDC6+MX6NoL/iSHy5iIikVFhhsPgquOIO2opnEsOgYrYuHouIZCAno5aOK4uv4qcH38jXH3yJDde9jfKy4nzXSERk3CusM4OE+qp4U9Guts40a4qICBRoGNRVKgxERIajIMOgIREGOw8qDEREMlGQYTBjSikl4RA727ryXRURkQmhIMMgFDJqK8vYqWYiEZGMFGQYANRVRHTNQEQkQwUbBvVVEV0zEBHJUMGGQV1lhL2Hu+iNxvJdFRGRca9gw6ChMoI77GnXRWQRkXQKNgyO3Wugi8giIukVbBgcuwtZ1w1ERNIr2DCorSgDdGYgIpKJgg2DsuIwM6aUqnupiEgGCjYMAOp145mISEYKOwyqIgoDEZEMFHQYHLsL2d3zXRURkXEtJ2FgZpea2ctmtsXMrkvyvpnZHYn3N5jZG3JRbjr1VRG6emMcONozFsWJiExYWYeBmYWBbwGXAYuAD5jZogGrXQYsSPytBL6dbbmZqNe9BiIiGcnFmcG5wBZ33+ruPcBPgBUD1lkB/IfH/R6oNLPaHJQ9JE1yIyKSmVyEQT2wo9/r5sSy4a4DgJmtNLMmM2tqaWnJqmINiRvPmnXjmYjIkHIRBpZk2cArtpmsE1/ovtrdG929sbq6OquKVUSKmVQSZpcmuRERGVIuwqAZmN3vdQOwawTr5JyZUV8ZYWdbx2gXJSIyoeUiDP4ALDCzeWZWAlwNrB2wzlrgo4leRUuAdnffnYOy06qrjOjMQEQkjaJsP8Dd+8zsWuAhIAz8wN03mtnHE+9/B1gHLAe2AB3Ax7ItN1P1VRFe2Nk+VsWJiExIWYcBgLuvI37A77/sO/2eO/CpXJQ1XPWVEQ4c7aGzJ0qkJJyPKoiIjHsFfQcy6F4DEZFMFHwY6F4DEZH0Cj4MXpvkRmEgIpJSwYfBzKmlhEOmGc9ERIZQ8GFQFA4xq7xMzUQiIkMo+DAAqKsso1lhICKSUiDCoL4yojMDEZEhBCIM6ioj7GnvIhrTJDciIskEIgzqqyL0xZx9hzUshYhIMoEIg2P3GqhHkYhIcoEIgwbdhSwiMqRAhEGdwkBEZEiBCIPJpUVUTipWjyIRkRQCEQYQ716qawYiIskFJgw0yY2ISGqBCYP49JedxKdWEBGR/gIVBke6+zjU1ZfvqoiIjDvBCYMq3WsgIpJKYMJA3UtFRFILTBjUa8YzEZGUAhMG0yeXUFIU0pmBiEgSWYWBmU0zs4fNbHPisSrJOrPN7FEz22RmG83sM9mUOVKhkL3Wo0hERE6U7ZnBdcB6d18ArE+8HqgP+Ly7nwYsAT5lZouyLHdE6irLdAFZRCSJbMNgBXBX4vldwJUDV3D33e7+bOL5YWATUJ9luSOiSW5ERJLLNgxmuvtuiB/0gZqhVjazucDZwFNZljsidZUR9h3uprsvmo/iRUTGraJ0K5jZI8CsJG/dMJyCzGwKcDfwWXc/NMR6K4GVAHPmzBlOEWkd61G0p72Lk6ZPzulni4hMZGnDwN2XpXrPzPaaWa277zazWmBfivWKiQfBj939njTlrQZWAzQ2NuZ07Ij6fpPcKAxERI7LtploLXBN4vk1wH0DVzAzA74PbHL3b2ZZXlZeuwtZ1w1ERE6QbRjcClxiZpuBSxKvMbM6M1uXWOd84CPAW83s+cTf8izLHZFZFWWAwkBEZKC0zURDcfdW4OIky3cByxPPfwtYNuXkSmlRmJqppepRJCIyQGDuQD6mTjeeiYgMErgwqK/SJDciIgMFLwwSZwaxmCa5ERE5JpBh0NMXo/VoT76rIiIybgQyDEA9ikRE+gtcGNRVasYzEZGBAhcGx248U/dSEZHjAhcG5WVFTCktUjORiEg/gQsDM01yIyIyUODCADTJjYjIQIEMg/qqCLvaFQYiIscEMgzqKiO0dfRytLsv31URERkXAhkGx+41UI8iEZG4QIdBs8JARAQIahjoXgMRkRMEMgxqppZRFDL1KBIRSQhkGIRDxqyKMp0ZiIgkBDIMQJPciIj0F9gwaKjUJDciIscENgzqKiPsOdRFXzSW76qIiORdYMOgvipCNObsPdyd76qIiORdYMNA8xqIiByXVRiY2TQze9jMNiceq4ZYN2xmz5nZL7IpM1eOz3jWkeeaiIjkX7ZnBtcB6919AbA+8TqVzwCbsiwvZ+oqywB0EVlEhOzDYAVwV+L5XcCVyVYyswbgHcD3siwvZyaVFDFtcgnNaiYSEck6DGa6+26AxGNNivX+Ffh7IG3XHTNbaWZNZtbU0tKSZfWGVl8Z0Y1nIiJAUboVzOwRYFaSt27IpAAzuxzY5+7PmNlF6dZ399XAaoDGxkbPpIyRqqss488tR0ezCBGRCSFtGLj7slTvmdleM6t1991mVgvsS7La+cA7zWw5UAaUm9mP3P3DI651jtRXTuI3m/fj7phZvqsjIpI32TYTrQWuSTy/Brhv4Arufr27N7j7XOBq4NfjIQggfmbQ0ROlraM331UREcmrbMPgVuASM9sMXJJ4jZnVmdm6bCs32hqqjnUv1XUDEQm2tM1EQ3H3VuDiJMt3AcuTLH8MeCybMnPptRvP2jo5o74iz7UREcmfwN6BDJr+UkTkmECHwbTJJZQVhzQkhYgEXqDDwMyoq4ywq11hICLBFugwgHhTkc4MRCToFAaVEXZqfCIRCbjAh0FdZYT9R7rp6o3muyoiInkT+DA41qNod7vODkQkuAIfBprkRkREYdDvLmRNciMiwRX4MJhZXoYZuogsIoEW+DAoKQoxc2qZmolEJNACHwYQH71UQ1KISJApDID6qkkauVREAk1hQPzMYHd7J7HYqE6sJiIybikMgIbKCL1Rp+VId76rIiKSFwoDoF6T3IhIwCkM0I1nIiIKAzTJjYiIwgCYWlbM1LIiNROJSGApDBLqKyM6MxCRwFIYJNRXRmjWNQMRCaiswsDMppnZw2a2OfFYlWK9SjP7mZm9ZGabzOy8bModDfVVOjMQkeDK9szgOmC9uy8A1ideJ3M78Et3PxV4PbApy3Jz7sKuR1kX+yR+cyXcdgZsWJPvKomIjJlsw2AFcFfi+V3AlQNXMLNy4ELg+wDu3uPubVmWm1sb1nDRK1+hIbQfw6F9B9y/SoEgIoGRbRjMdPfdAInHmiTrzAdagP9rZs+Z2ffMbHKW5ebW+lsoig4Ywrq3E9bfkp/6iIiMsbRhYGaPmNmLSf5WZFhGEfAG4NvufjZwlNTNSZjZSjNrMrOmlpaWDIvIUnvz8JaLiBSYonQruPuyVO+Z2V4zq3X33WZWC+xLsloz0OzuTyVe/4whwsDdVwOrARobG8dm5LiKhnjTULLlIiIBkG0z0VrgmsTza4D7Bq7g7nuAHWa2MLHoYuBPWZabWxffCMWRE5cVR+LLRUQCINswuBW4xMw2A5ckXmNmdWa2rt96nwZ+bGYbgLOAr2VZbm4tvgquuIPuyfXE3OiI1MIVd8SXi4gEgLmP3zH8GxsbvampaczKi8acxq88zEULa7jt/WeNWbkiIrliZs+4e+Nwt9MdyP2EQ8ZbTqnm8VdaiGqiGxEJEIXBAEtPreHA0R42NI+vWyFEREaTwmCACxdUEzJ49KVkHaNERAqTwmCAqsklnD2nikdfHqN7HERExgGFQRJLF1bzws529h3uSr+yiEgBUBgksfTU+Kgaj+vsQEQCQmGQxKLacmqmlvKYwkBEAkJhkISZsXRhDU+80kJvNJbv6oiIjDqFQQpLT63mcHcfz7x6MN9VEREZdQqDFM5/3QyKw8ajL6uLqYgUPoVBClPLijln7jQee0nXDUSk8CkMhrB0YQ0v7z3MTs2NLCIFTmEwhKWnVgO6G1lECp/CYAgnV0+hoSrCY7puICIFTmEwhGNdTJ/c0kpXbzTf1RERGTUKgzTeemoNnb1Rnt52IN9VEREZNQqDNJbMn05pUUhdTEWkoCkM0oiUhDnv5Om6iCwiBU1hkIGlC2v4S2sH2/YfzXdVRERGhcIgA0sXxkcx1dmBiBQqhUEG5kyfxMnVk3XdQEQKlsIgQ0sX1vDU1gN09PTluyoiIjmXVRiY2TQze9jMNiceq1Ks9zkz22hmL5rZf5lZWTbl5sPSU2voicZ4cktrvqsiIpJz2Z4ZXAesd/cFwPrE6xOYWT2wCmh09zOAMHB1luWOuXPmTmNySVhNRSJSkLINgxXAXYnndwFXplivCIiYWREwCdiVZbljrqQoxAULZvDYS/tw93xXR0Qkp7INg5nuvhsg8VgzcAV33wn8b2A7sBtod/dfZVluXixdWMOu9i5e2Xsk31UREcmptGFgZo8k2voH/q3IpIDEdYQVwDygDphsZh8eYv2VZtZkZk0tLeNrLoGLjnUxVVORiBSYtGHg7svc/Ywkf/cBe82sFiDxmOwouQzY5u4t7t4L3AO8eYjyVrt7o7s3VldXj+xfNUpmVZRxWm05v9b9BiJSYLJtJloLXJN4fg1wX5J1tgNLzGySmRlwMbApy3LzZunCap559SDtnb35roqISM5kGwa3ApeY2WbgksRrzKzOzNYBuPtTwM+AZ4EXEmWuzrLcvHnrqTVEY85vN+/Pd1VERHKmKJuN3b2V+C/9gct3Acv7vb4JuCmbssaLs2ZXUhEp5tGX9/GOxbX5ro6ISE7oDuRhKgqHuPCUah57uYVYTF1MRaQwKAxGYOnCavYf6ebFXe35roqISE4oDEbgLadUYwaPvjS+ur6KiIyUwmAEpk8p5fUNlbrfQEQKhsJghJYurOGPzW20HunOd1VERLKmMBihpadW4w5PbFZTkYhMfAqDETqjroIZU0r5ta4biEgBUBiMUChkXLSwmideaaEvGst3dUREsqIwyMLShTW0d/by/I62fFdFRCQrCoMsLO15jCdLV/HG/zcfbjsDNqzJd5VEREYkq+EoAm3DGiY99DkmWWf8dfsOuH9V/Pniq/JXLxGREdCZwUitvwV6O09c1tsZXy4iMsEoDEaqvXl4y0VExjGFwUhVNAxvuYhMPBvWxK8H3lw5vOuCY71dDuiawUhdfGP8GkG/pqJOSvG/uoFJeayWSMHbsCbeHNveHP/xdfGNmV2nG+52G9ac+P94ptcFk2zn96+ity9G16L3EI06vbEYfVGP/8Vi9MWcyEt3U//EdYSi+bkOae7jdxjmxsZGb2pqync1Uuv35eqZUsfft11J2dlXc+t7Fue7ZiLj30gO6gMPtADFEbjijpTbujs9z/2UknWfxfqObxcNR3j53K+wvf5yuvuidPVG6eqN0dUbpbsvxjVPXU5Fz55Bn7c/XMNna39ETzRGT1/8rzcaoycao7cvxt3dK6ll8ORXzbEZXNBzR8p/2m9LVtEQSjJpVsVs+NyLQ+yUE5nZM+7emPEGCTozyMbiq177ApYAMx/cxHcf38o7z6rjzSfPyG/dRMZKLg7qSX4Fd/VGOdTZy6GuXto7+zjU1cubHryRSUk6brSu/RJ/1zSXjp4+jnZH4489UTq6++jojfKb4htoCJ24XTjaSfmTX+fjPcknqbq2dA/Y4OXToi109PRRUhRialkRpUUhisMhShKPsza2Jv28+lArX3rHaRSFjHA4RHHIKAqHKAoZRWGj/p7k243VdUiFQQ59btkp/PLFPVx/zws89NkLKSsO57tKIqMrg4N6XzTGwY5eDhztofVoNweO9nDRuhuZkuSgvufeL3L52mkc6uqlp2/wnf1bS3cnPUBX9e2jrbOXySVh6ipLmFwaZlJJEZNLwkwqLaL+ydQH6AdWXUBZcTj+VxSiNPEYumN2/N8zQKiigXs+eX7qfdLckHQ7q2jgb/5qfurt1iffbqyuQyoMcqisOMzX330mH/z3p/jXRzZz3WWn5rtKIpkbxi/8aMxpPdJN5a9upiTJQb3l5zfw/odrOHC0h/bOXga2Rqc6qM/0/VyyaCYVkWLKI0WUlxVTHimmvKyI8kgx0TX1hI7sHLRdqKKB+z41xAH6xdQH6NPrKpJvk+S6IMWR+PKhjPV2OaIwyLE3nzyD9zfO5t9/s5XLF9dyRn2KL5rIeJLkF370vlU8+5eDPFOxjD3tXew91MWeQ13sae9i3+FuojFna+nOpAf16bEWTptVzrTJJUybXML0KSXHn08uxX/cAIcHN39YRQNff/eZqev5tpvH7kB7LAiH2wQ21tvliC4gj4L2jl6W3fY4NVNLue9T51MUVg9eGUNpfuHHYs7ew1282trB9gMd7DjQwceevoJpfXsHfdSxi55TSouYVVHGrPIyZpaXMauilFnlZbz3N5cR6dg1uA7pLnqO4EJwpv++nG83wYz0ArLCYJQ8+MJuPvHjZ7n+slP5n285Od/VkYkq2+6QQG+ojJ/P/gce4AK2H+ig+UAnPf1G2g0ZbCn9ECEGHwsc4+j1+5lSmqIRIR8HdRlSXnoTmdn7gJuB04Bz3T3pkdvMLgVuB8LA99z91mzKnQguO7OWt58+k28+/ApvP30Wc2dMzneVZKLJ4OLs4a5e/txylM17D7Ol5Qh/23QDM6IntuEXx7o4/9Vvcdf0czh11lQuWTSTOdMmvfZXVxkhdEfqNvWUQdCvHiM6qPfrjSf5l9WZgZmdBsSA7wJfSBYGZhYGXgEuAZqBPwAfcPc/pfv8iXxmALD3UBfLvvE4Z9RX8J9/+ybMkjSuiqRy2xlJD9BtJTP59MwfsmXfEXa3d722vCQc4qXiDyT9hQ8GNw8x1Ho2v/BlXMnLmYG7b0oUPtRq5wJb3H1rYt2fACuAtGEw0c0sL+P65afxxXtfYE3TDt5/zpx8V0nyJcMmkVjM2dZ6lD/tOsTl7c3Jrs1S3r2Pto5ezps/nZNrprCgZgqvq5nCnGmTUv7CT9s9Mc8XLyX/xqI3UT3Q/9vZDLwp1cpmthJYCTBnzsQ/eF59zmzue34nX31gE0sX1lBTXpbvKslYS9Hc0xuL8XL1ZWzc1c7GXYfYuOsQm3YfoqMnCsAbSqdTb4PvSLXKBu7/9AXJy8qme6KabQItbRiY2SPArCRv3eDu92VQRrIfNynbptx9NbAa4s1EGXz+uBYKGV9/95lcevtvuPn+jdz5oTfmu0oy1lIMd77v3hu4vHsqAJNLwiyqK+eqxtksqivn9LpyZu77GjzwmUEHdhuN7pASeGnDwN2XZVlGMzC73+sGIElftMI1v3oKn7l4Af/y0Ms8tHEPbz89WbbKhJBBc4+785fWDp7bfpDntrfx5fbmpMMD11kr//bBszm9roKTpk0iFBrwu6nu/fGuPiPpr66DvwzTWDQT/QFYYGbzgJ3A1cAHx6DccWXlhfP5xYbd/K+fv8iS+dOpiBTnu0oyXCmaezp6ojSVL+O57W08t+Mgz+9oo62jF4j/4l9VXE11dN+gj7OKBi5fXDd0mTqwyxjJtmvpu4D/A1QDD5jZ8+7+djOrI96FdLm795nZtcBDxLuW/sDdN2Zd8wmmOBzin95zJld+60n+6Zcv8bV3DXGXpYxPKZp7Dqz9Eh/tKccMFtRM4e2LZnHWnErOnlPJgpqphF/8al6HGRDJRLa9ie4F7k2yfBewvN/rdcC6bMoqBIsbKvmbv5rP6ie28s7X17Fk/vR8V0nS6OmL8cLONp7edpCPp+jdUx9q5Ud//SYWz66gvCzJGZ/a8WUC0NhEY+xzy06h77mfMveHn8F9P6YDQ36kaPs/0t3HM68epOkvB3h62wGe39FGd2L0zHdFZjDLWwZ9lFU0cMGCNEOWq7lHxjmFwRiLvHQ3N8S+Q9jzM5uRkLTtv+fea7n9oZf49oE3EnMIh4zT68r58JKTOGduFY1zpzFj69fU3CMFS2Ew1tbfQjg6uN2Z9bcoDMbAvkNdTHnwpkETpJR4N/+j64eEl76fc+ZN4+w5VYOHYVBzjxQwhcFYSzFrkadoj5Y00nT13NPexVPbWvn91lae2nqArfuPsrV0V9K7X6qjLfzd2xYOXZ6ae6RAKQzGWkXy4QJ2+nR++OAmPrfsFM2QlqkkzT2xtat45i8H+FnPm3lqWyt/ae0AYGpZEefOncYHzp1D39P1lCSZIGWsZpQSGY8UBmMtyXABXhTht7Wf4LuPb+XXm/bxjatez+KGyjxWcmLw9bdgA5p7Qn2d1Db9Cw+G7uTcedP58JKTWDJ/OqfVlhM+dlNX5c1q+xcZQGEw1pK0O9vFN3L14quY9fI+rrv7Bd515+/45EUn8+m3LqCkSBPjHOPu/LnlCE9ti/f0uW2Irp7P3fi24wf/gdT2LzKIJrcZZ9o7e/ny/Ru559mdnFZbzjfe93oW1ZXnu1qjL0nbf/SM9/HSnkM8nTj4P73tAK1HewConlrKL/2TTE8yO1faWbZECphmOiswD/9pL9ff8wLtnT2seusCPn7RyRQX6vSZScbS77ZSbvSV/LTrPAAaqiKcO28ab5o3jXPnTWfu9EnYC/+tMfhFBlAYFKCDR3u4ce1G7v/jLs6sr2D1WVupbfrngmjacHdebe3g+R1tXLRuKZW9g3/hHyyeyePLH+WcedOor4wk/yBNnShyAoVBAXtgw26evPdOvhT7DpOs5/gb4/VXcJID9MGTr+T55jae397G8zva+GPz8cHctpZ+iJCNYHYuERkkLzOdydh4x+JaLn34HsKHe058o7eT3l/dTPiM9w0e/jhfNqzB167C+o539+y651pu6nmOtbELCBmcMnPqa4O5nTW7EvtJffL7L9TVU2TMKAwmiPDhJP3igfDhXZz9jw9z1uz4KJlnz6nirNmVJw6RPdKmlCG26+6Lsr21I34TV8tRtu0/wrb9R7l9z/XUcWJ3zzK6+erUe/nAVV/gzIaKwXf2XnyTunqK5JnCYKJIcbNa56RZLF8wi2dfbeP29Zs51ur3upopnD27kncV/Y4lG79MqG/osZBiMac3FqM36vT2xQi9+N9MffjzJ2zXc++1/ODxP/OfnUtoPthBrF/LzowppcyvnkwtrUmrP7V7D+ednGKUVnX1FMk7XTOYKJL0uBl4zeBwVy8bmtt5bvtBnt3exnPbD3J/3ydoCA2eR3cXM3g7d9IbjQdANHbi9+C3JauSbrc3VM0/vm4N82dMZn71FObNmMy86snHh26+7YwUE7Kru6fIWNA1g0KXwa/nqWXFnP+6GZz/uvhwyu4OX07+S72WVt77xgaKwyGKw5Z4PP68/uHk282M7effPviG1PXMZkJ2EckbhcFEMsxB0swsZfOSVTRw0xWnp9746eTbpb2oqyYfkQlJYVDoRvpLPZtf+BrZU2TCKdBbWuU1i6+KX1eomA1Y/DGTexNGup2ITEi6gCwiUkBGegFZZwYiIpJdGJjZ+8xso5nFzCxpEpnZbDN71Mw2Jdb9TDZliohI7mV7ZvAi8G7giSHW6QM+7+6nAUuAT5nZoizLFRGRHMqqN5G7b4JEF8bU6+wGdieeHzazTUA98KdsyhYRkdwZ02sGZjYXOBt4aizLFRGRoaU9MzCzR4BZSd66wd3vy7QgM5sC3A181t0PDbHeSmBl4uURM3s50zImoBnA4DEfgk37JDntl8G0TwabAZw0kg1z0rXUzB4DvuDuSfuBmlkx8AvgIXf/ZtYFFggzaxpJF7BCpn2SnPbLYNong2WzT0a9mcjiFxS+D2xSEIiIjE/Zdi19l5k1A+cBD5jZQ4nldWa2LrHa+cBHgLea2fOJv+VZ1VpERHIq295E9wL3Jlm+C1ieeP5bYJxMwzXurM53BcYh7ZPktF8G0z4ZbMT7ZFwPRyEiImNDw1GIiIjCYCyY2aVm9rKZbTGz65K8f5GZtfe7plLwM8GY2Q/MbJ+ZJZ3+zOLuSOyzDWY2xIw6hSGDfRLE70na4WyC9l3JcJ8M/7vi7vobxT8gDPwZmA+UAH8EFg1Y5yLgF/mu6xjvlwuBNwAvpnh/OfAg8etNS4Cn8l3ncbBPgvg9qQXekHg+FXglyf8/gfquZLhPhv1d0ZnB6DsX2OLuW929B/gJsCLPdco7d38CODDEKiuA//C43wOVZlY7NrXLjwz2SeC4+253fzbx/DBwbDib/gL1XclwnwybwmD01QP9549sJvl/uPPM7I9m9qCZDTEfZWBkut+CJrDfkyGGswnsdyXNED/D+q5o2svRl6xb7cAuXM8CJ7n7kcQ9GD8HFox6zca3TPZb0AT2e5JmOJtAflfS7MMHLuQAAAEXSURBVJNhf1d0ZjD6moHZ/V43ALv6r+Duh9z9SOL5OqDYzGaMXRXHpbT7LWiC+j1JDGdzN/Bjd78nySqB+66k2ycj+a4oDEbfH4AFZjbPzEqAq4G1/Vcws1mJYTsws3OJ/3dpHfOaji9rgY8meoosAdo9Phx6YAXxe5LhcDaB+q5ksk9G8l1RM9Eoc/c+M7sWeIh4z6IfuPtGM/t44v3vAO8FPmFmfUAncLUnugQUKjP7L+I9HmYkhjS5CSiG1/bJOuK9RLYAHcDH8lPTsZPBPgnc94Tjw9m8YGbPJ5Z9EZgDgf2uZLJPhv1d0R3IIiKiZiIREVEYiIgICgMREUFhICIiKAxERASFgYiIoDAQEREUBiIiAvx//WDb5aI+NDsAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from blueqat import *\n",
+    "from openfermion import *\n",
+    "from openfermionblueqat import*\n",
+    "import numpy as np\n",
+    "\n",
+    "def get_molecule(bond_len):\n",
+    "  geometry = [('H',(0.,0.,0.)),('H',(0.,0.,bond_len))]\n",
+    "\n",
+    "  description = format(bond_len)\n",
+    "  molecule = MolecularData(geometry, \"sto-3g\",1,description=description)\n",
+    "\n",
+    "  molecule.load()\n",
+    "  return molecule\n",
+    "\n",
+    "x = [];e=[];fullci=[]\n",
+    "for bond_len in np.arange(0.2,2.5,0.1):\n",
+    "  m = get_molecule(\"{:.2}\".format(bond_len))\n",
+    "  h = bravyi_kitaev(get_fermion_operator(m.get_molecular_hamiltonian()))\n",
+    "  runner = vqe.Vqe(UCCAnsatz(h,6,Circuit().x[0]))\n",
+    "  result = runner.run()\n",
+    "  x.append(bond_len)\n",
+    "  e.append(runner.ansatz.get_energy_sparse(result.circuit))\n",
+    "  fullci.append(m.fci_energy)\n",
+    "\n",
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "plt.plot(x,fullci)\n",
+    "plt.plot(x,e,\"o\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "102vqe_qaoa02.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/tutorial/601_optimizer_en.ipynb
+++ b/tutorial/601_optimizer_en.ipynb
@@ -1,242 +1,255 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "051_classical_opt.ipynb",
-      "provenance": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "WAr8pX3MY4bC"
+   },
+   "source": [
+    "#Set up a classical optimization solver"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "WAr8pX3MY4bC",
-        "colab_type": "text"
-      },
-      "source": [
-        "#Set up a classical optimization solver"
-      ]
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "spfbaZ2uY8Xg"
+   },
+   "source": [
+    "Here we see the classical optimization solver used in VQE or QAOA quantum-classical hybrid algorithms."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 68
     },
+    "colab_type": "code",
+    "id": "PLrhMb4HWmTy",
+    "outputId": "119b026a-e905-4b83-f1cb-685cbb0a4d47"
+   },
+   "outputs": [
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "spfbaZ2uY8Xg",
-        "colab_type": "text"
-      },
-      "source": [
-        "Here we see the classical optimization solver used in VQE or QAOA quantum-classical hybrid algorithms."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "PLrhMb4HWmTy",
-        "colab_type": "code",
-        "outputId": "119b026a-e905-4b83-f1cb-685cbb0a4d47",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 68
-        }
-      },
-      "source": [
-        "!pip install blueqat"
-      ],
-      "execution_count": 21,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Requirement already satisfied: blueqat in /usr/local/lib/python3.6/dist-packages (0.3.13)\n",
-            "Requirement already satisfied: scipy>=1.1.0 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.4.1)\n",
-            "Requirement already satisfied: numpy~=1.12 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.17.5)\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "PAtDORE3ae49",
-        "colab_type": "text"
-      },
-      "source": [
-        "When we calculate the ansatz we just set up the minimizer."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "h7NQ9kuEZW42",
-        "colab_type": "code",
-        "outputId": "a2526be9-cfdc-4758-f2d2-b421c0df4a53",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 85
-        }
-      },
-      "source": [
-        "import numpy as np\n",
-        "from blueqat import Circuit\n",
-        "from blueqat.pauli import X, Y, Z, I\n",
-        "from blueqat.pauli import qubo_bit as q\n",
-        "from blueqat.vqe import AnsatzBase, Vqe, get_scipy_minimizer\n",
-        "\n",
-        "class QubitAnsatz(AnsatzBase):\n",
-        "    def __init__(self, hamiltonian):\n",
-        "        super().__init__(hamiltonian, 4)\n",
-        "        self.step = 1\n",
-        "\n",
-        "    def get_circuit(self, params):\n",
-        "        a, b, c, d = params\n",
-        "        return Circuit().ry(a)[0].rz(b)[0].ry(c)[1].rz(d)[1]\n",
-        "\n",
-        "h = -3*q(0)-3*q(1)-2*q(0)*q(1)\n",
-        "h = h.to_expr().simplify()\n",
-        "minimizer = get_scipy_minimizer(method=\"COBYLA\",options={\"tol\":5.0e-4})\n",
-        "runner = Vqe(QubitAnsatz(h),minimizer=minimizer)\n",
-        "result = runner.run()\n",
-        "\n",
-        "print('Result by VQE')\n",
-        "print(runner.ansatz.get_energy(result.circuit, runner.sampler))\n",
-        "\n",
-        "# Hamiltonian to matrix\n",
-        "mat = h.to_matrix()\n",
-        "\n",
-        "# Calculate by numpy\n",
-        "print('Result by numpy')\n",
-        "print(np.linalg.eigh(mat)[0][0])"
-      ],
-      "execution_count": 22,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Result by VQE\n",
-            "-7.999999738356178\n",
-            "Result by numpy\n",
-            "-8.0\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "K685AxwIaljb",
-        "colab_type": "text"
-      },
-      "source": [
-        "##Other solvers\n",
-        "If you want to use your own solver, it can be set up by making a function. This time we try to use bayesian optimization solver \"hyperopt\"."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "aV8SOqfRaAl3",
-        "colab_type": "code",
-        "outputId": "65540049-9ade-4fb2-f9bd-ccb73f857726",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 170
-        }
-      },
-      "source": [
-        "!pip install hyperopt"
-      ],
-      "execution_count": 24,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Requirement already satisfied: hyperopt in /usr/local/lib/python3.6/dist-packages (0.1.2)\n",
-            "Requirement already satisfied: tqdm in /usr/local/lib/python3.6/dist-packages (from hyperopt) (4.28.1)\n",
-            "Requirement already satisfied: future in /usr/local/lib/python3.6/dist-packages (from hyperopt) (0.16.0)\n",
-            "Requirement already satisfied: networkx in /usr/local/lib/python3.6/dist-packages (from hyperopt) (2.4)\n",
-            "Requirement already satisfied: pymongo in /usr/local/lib/python3.6/dist-packages (from hyperopt) (3.10.1)\n",
-            "Requirement already satisfied: six in /usr/local/lib/python3.6/dist-packages (from hyperopt) (1.12.0)\n",
-            "Requirement already satisfied: scipy in /usr/local/lib/python3.6/dist-packages (from hyperopt) (1.4.1)\n",
-            "Requirement already satisfied: numpy in /usr/local/lib/python3.6/dist-packages (from hyperopt) (1.17.5)\n",
-            "Requirement already satisfied: decorator>=4.3.0 in /usr/local/lib/python3.6/dist-packages (from networkx->hyperopt) (4.4.1)\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "10pef-zmaC4_",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "def hyperopt_minimizer(objective, n_params):\n",
-        "    from hyperopt import fmin, Trials, tpe, hp\n",
-        "    trials = Trials()\n",
-        "    best = fmin(objective, [hp.uniform(f'p{i}', 0., 2 * np.pi) for i in range(n_params)],\n",
-        "            algo=tpe.suggest, max_evals=100, trials=trials, verbose=1)\n",
-        "    return list(best.values())"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "1g5HGGY-Zt9P",
-        "colab_type": "code",
-        "outputId": "dc03c61a-9aed-40f9-9410-dc151e7262d6",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 102
-        }
-      },
-      "source": [
-        "runner = Vqe(QubitAnsatz(h),minimizer=hyperopt_minimizer)\n",
-        "result = runner.run()\n",
-        "\n",
-        "print('Result by VQE')\n",
-        "print(runner.ansatz.get_energy(result.circuit, runner.sampler))\n",
-        "\n",
-        "# Hamiltonian to matrix\n",
-        "mat = h.to_matrix()\n",
-        "\n",
-        "# Calculate by numpy\n",
-        "print('Result by numpy')\n",
-        "print(np.linalg.eigh(mat)[0][0])"
-      ],
-      "execution_count": 26,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "100%|██████████| 100/100 [00:01<00:00, 87.43it/s, best loss: -7.879139761619782]\n",
-            "Result by VQE\n",
-            "-7.879139761619782\n",
-            "Result by numpy\n",
-            "-8.0\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "7MCJJcpCbM3h",
-        "colab_type": "text"
-      },
-      "source": [
-        "We succeded to set up an optimizer."
-      ]
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: blueqat in /usr/local/lib/python3.6/dist-packages (0.3.13)\n",
+      "Requirement already satisfied: scipy>=1.1.0 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.4.1)\n",
+      "Requirement already satisfied: numpy~=1.12 in /usr/local/lib/python3.6/dist-packages (from blueqat) (1.17.5)\n"
+     ]
     }
-  ]
+   ],
+   "source": [
+    "!pip install blueqat"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "PAtDORE3ae49"
+   },
+   "source": [
+    "When we calculate the ansatz we just set up the minimizer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 85
+    },
+    "colab_type": "code",
+    "id": "h7NQ9kuEZW42",
+    "outputId": "a2526be9-cfdc-4758-f2d2-b421c0df4a53"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Result by VQE\n",
+      "-7.999999648951572\n",
+      "Result by numpy\n",
+      "-8.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from blueqat import Circuit\n",
+    "from blueqat.pauli import X, Y, Z, I\n",
+    "from blueqat.pauli import qubo_bit as q\n",
+    "from blueqat.vqe import AnsatzBase, Vqe, get_scipy_minimizer\n",
+    "\n",
+    "class QubitAnsatz(AnsatzBase):\n",
+    "    def __init__(self, hamiltonian):\n",
+    "        super().__init__(hamiltonian, 4)\n",
+    "        self.step = 1\n",
+    "\n",
+    "    def get_circuit(self, params):\n",
+    "        a, b, c, d = params\n",
+    "        return Circuit().ry(a)[0].rz(b)[0].ry(c)[1].rz(d)[1]\n",
+    "\n",
+    "h = -3*q(0)-3*q(1)-2*q(0)*q(1)\n",
+    "h = h.to_expr().simplify()\n",
+    "minimizer = get_scipy_minimizer(method=\"COBYLA\",options={\"tol\":5.0e-4})\n",
+    "runner = Vqe(QubitAnsatz(h),minimizer=minimizer)\n",
+    "result = runner.run()\n",
+    "\n",
+    "print('Result by VQE')\n",
+    "print(runner.ansatz.get_energy_sparse(result.circuit))\n",
+    "\n",
+    "# Hamiltonian to matrix\n",
+    "mat = h.to_matrix()\n",
+    "\n",
+    "# Calculate by numpy\n",
+    "print('Result by numpy')\n",
+    "print(np.linalg.eigh(mat)[0][0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "K685AxwIaljb"
+   },
+   "source": [
+    "##Other solvers\n",
+    "If you want to use your own solver, it can be set up by making a function. This time we try to use bayesian optimization solver \"hyperopt\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 170
+    },
+    "colab_type": "code",
+    "id": "aV8SOqfRaAl3",
+    "outputId": "65540049-9ade-4fb2-f9bd-ccb73f857726"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: hyperopt in /usr/local/lib/python3.6/dist-packages (0.1.2)\n",
+      "Requirement already satisfied: tqdm in /usr/local/lib/python3.6/dist-packages (from hyperopt) (4.28.1)\n",
+      "Requirement already satisfied: future in /usr/local/lib/python3.6/dist-packages (from hyperopt) (0.16.0)\n",
+      "Requirement already satisfied: networkx in /usr/local/lib/python3.6/dist-packages (from hyperopt) (2.4)\n",
+      "Requirement already satisfied: pymongo in /usr/local/lib/python3.6/dist-packages (from hyperopt) (3.10.1)\n",
+      "Requirement already satisfied: six in /usr/local/lib/python3.6/dist-packages (from hyperopt) (1.12.0)\n",
+      "Requirement already satisfied: scipy in /usr/local/lib/python3.6/dist-packages (from hyperopt) (1.4.1)\n",
+      "Requirement already satisfied: numpy in /usr/local/lib/python3.6/dist-packages (from hyperopt) (1.17.5)\n",
+      "Requirement already satisfied: decorator>=4.3.0 in /usr/local/lib/python3.6/dist-packages (from networkx->hyperopt) (4.4.1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install hyperopt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "10pef-zmaC4_"
+   },
+   "outputs": [],
+   "source": [
+    "def hyperopt_minimizer(objective, n_params):\n",
+    "    from hyperopt import fmin, Trials, tpe, hp\n",
+    "    trials = Trials()\n",
+    "    best = fmin(objective, [hp.uniform(f'p{i}', 0., 2 * np.pi) for i in range(n_params)],\n",
+    "            algo=tpe.suggest, max_evals=100, trials=trials, verbose=1)\n",
+    "    return list(best.values())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 102
+    },
+    "colab_type": "code",
+    "id": "1g5HGGY-Zt9P",
+    "outputId": "dc03c61a-9aed-40f9-9410-dc151e7262d6"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 220.25trial/s, best loss: -7.979784958184596]\n",
+      "Result by VQE\n",
+      "-7.979784958184596\n",
+      "Result by numpy\n",
+      "-8.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "runner = Vqe(QubitAnsatz(h),minimizer=hyperopt_minimizer)\n",
+    "result = runner.run()\n",
+    "\n",
+    "print('Result by VQE')\n",
+    "print(runner.ansatz.get_energy_sparse(result.circuit))\n",
+    "\n",
+    "# Hamiltonian to matrix\n",
+    "mat = h.to_matrix()\n",
+    "\n",
+    "# Calculate by numpy\n",
+    "print('Result by numpy')\n",
+    "print(np.linalg.eigh(mat)[0][0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "7MCJJcpCbM3h"
+   },
+   "source": [
+    "We succeded to set up an optimizer."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "051_classical_opt.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
Due to modification of vqe module in Blueqat 0.3.17,
`runner.ansatz.get_energy(result.circuit, runner.sampler)` raises error but `runner.ansatz.get_energy_sparse(result.circuit)` is an alternative solution.

I modified tutorials which is in use `get_energy` method.