### PR TITLE
Translate the new version of 121_qft_en to Japanese

### DIFF
--- a/tutorial-ja/121_qft_ja.ipynb
+++ b/tutorial-ja/121_qft_ja.ipynb
@@ -8,7 +8,20 @@
    },
    "source": [
     "# 量子フーリエ変換\n",
-    "量子フーリエ変換は既存計算機の高速フーリエ変換に対応したアルゴリズムです。高速フーリエ変換の資料はたくさんあると思いますので、今回は量子フーリエ変換QFTを見てみます。\n"
+    "\n",
+    "古典的なフーリエ変換は波や信号の解析において重要なツールであり、関数をそれぞれ異なる周波数を持つ成分に分解します。\n",
+    "\n",
+    "この離散的な対応である離散フーリエ変換は、$n$ 個の複素数 $x_0,\\ldots,x_{N-1}$ に作用し、次式のように、別の $n$ 個の複素数列 $\\tilde x_0,\\ldots,\\tilde x_{N-1}$ へと変換します。\n",
+    "\n",
+    "$$\\tilde x_k = \\sum_{y=0}^{N-1}e^{-\\frac{2\\pi ikn}N} \\cdot x_k$$\n",
+    "\n",
+    "$n$ 個の量子ビットに対する量子フーリエ変換（一般にQFTと略します）は各基底状態 $x\\in \\{0,1\\}^n$ に対して同様にはたらき、次式のように表されます（ただし、$N=2^n$）。\n",
+    "\n",
+    "$$\\text{QFT}(\\lvert x\\rangle) = \\frac 1{\\sqrt N}\\sum_{y=0}^{N-1}e^{\\frac{2\\pi ixy}N}\\lvert y\\rangle\\qquad \\qquad (1)$$\n",
+    "\n",
+    "ここでは、ビット列 $x\\in\\{0, 1\\}^n$ を整数 $\\sum_{j=0}^{n-1}2^{n-1-j}x_j$ として表記するものとします。\n",
+    "\n",
+    "QFTは事実上、計算基底から \"フーリエ基底\" に基底を変換したものと考えることができます。"
    ]
   },
   {
@@ -18,8 +31,34 @@
     "id": "CJhIv6UdASWQ"
    },
    "source": [
-    "## 量子フーリエ変換とは？\n",
-    "フーリエ変換は時系列の波を周波数ごとに分解します。フーリエ変換の中で離散値をとるものが離散フーリエ変換で、それを計算機上で高速処理するアルゴリズムが高速フーリエ変換です。量子フーリエ変換はこの高速フーリエ変換を量子コンピュータを使って計算を行います。"
+    "## QFTのテンソル積分解\n",
+    "\n",
+    "いくつかの代数的な操作によって、式$(1)$の総和を純粋状態同士のテンソル積へと分解できることがわかります。\n",
+    "\n",
+    "$$\\text{QFT}(\\lvert x\\rangle) = \\frac 1{\\sqrt N}\\left(\\vert 0\\rangle + e^{\\frac{2\\pi ix}{2^1}}\\vert 1\\rangle\\right)\\otimes \\left(\\vert 0\\rangle + e^{\\frac{2\\pi ix}{2^2}}\\vert 1\\rangle\\right)\\otimes \\cdots \\otimes \\left(\\vert 0\\rangle + e^{\\frac{2\\pi ix}{2^n}}\\vert 1\\rangle\\right).$$\n",
+    "\n",
+    "この定式化により、QFTを実現する量子回路をどのように実装すればよいかが明確になります。\n",
+    "\n",
+    "## 制御位相回転\n",
+    "\n",
+    "回路構成を見る前に、次のゲートを定義します。\n",
+    "\n",
+    "$$R_k = \\begin{pmatrix}1 & 0\\\\ 0 & e^{\\frac{2\\pi i}{2^k}}\\end{pmatrix},$$\n",
+    "\n",
+    "そしてこのゲートを制御ゲート化したものが、制御量子ビットの値に応じてターゲット量子ビットの位相を変えることを思い出しましょう。  \n",
+    "言い換えると、$CR_k(\\lvert 0\\rangle|x\\rangle) = |0\\rangle \\lvert x\\rangle$ かつ\n",
+    "\n",
+    "\\begin{aligned}CR_k(\\lvert 1\\rangle \\lvert x\\rangle) = \\lvert 1\\rangle\\otimes R_k(\\lvert x \\rangle) &=\\lvert 1\\rangle\\otimes R_k\\left( \\langle 0\\lvert x\\rangle \\lvert  0\\rangle + \\langle 1 \\lvert x\\rangle \\lvert 1\\rangle\\right)\n",
+    " \\\\ & = \\lvert 1\\rangle\\otimes \\left( \\langle 0 \\lvert x\\rangle \\lvert  0\\rangle + \\langle 1 \\lvert x\\rangle e^{\\frac{2\\pi i}{2^k}} \\lvert 1\\rangle\\right)\\end{aligned}\n",
+    " \n",
+    " となります。\n",
+    "\n",
+    "より簡潔に、次のように表されます。\n",
+    "\n",
+    "$$CR_k(\\lvert y\\rangle \\lvert x\\rangle) = \\lvert y\\rangle \\otimes \\left( \\langle 0 \\vert x\\rangle \\lvert  0\\rangle + \\langle 1 \\vert x\\rangle e^{\\frac{2\\pi iy}{2^k}} \\lvert 1\\rangle\\right).$$\n",
+    "\n",
+    "よって、  \n",
+    "$$CR_k = \\begin{pmatrix}1 & 0 & 0 & 0\\\\ 0 & 1 & 0 & 0\\\\ 0& 0& 1 & 0\\\\ 0 & 0&0 &e^{\\frac{2\\pi i}{2^k}}\\end{pmatrix} = \\text{CPhase}\\left(\\frac{2\\pi}{2^k}\\right).$$"
    ]
   },
   {
@@ -29,10 +68,14 @@
     "id": "oXg3hf3yAkMS"
    },
    "source": [
-    "## 数理\n",
-    "高速フーリエ変換にとても似ています（が符号が違う気が、、、）。ある量子状態を別の量子状態に写します。\n",
+    "## 回路構造\n",
     "\n",
-    "$$QFT:\\mid x \\rangle \\mapsto \\frac{1}{\\sqrt{N}}\\sum_{k=0}^{N-1} \\omega_n^{xk}\\mid k\\rangle \\\\ \\omega_n = e^{\\frac{2\\pi i}{N}}$$"
+    "これで、QFTを実現する回路を構築するために必要な材料が揃いました。  \n",
+    "以下は、$n=4$量子ビットの回路例です。\n",
+    "\n",
+    "![Circuit Image](../tutorial/img/121_qft_ckt.png)\n",
+    "\n",
+    "ここでは、$\\lvert \\varphi_1\\rangle$から$\\lvert \\varphi_4\\rangle$までの状態を見ていきます。"
    ]
   },
   {
@@ -42,25 +85,24 @@
     "id": "U1uxGVsCCi85"
    },
    "source": [
-    "## ビットを入力し、位相を量子状態で出力\n",
-    "量子フーリエ変換の入力は01のビットになります。これらのビット入力が位相の形で量子状態として出力されます。出力状態をテンソル積を用いて表現すると、\n",
+    "$\\lvert \\varphi_1\\rangle$ において、先頭の量子ビットの状態を、基底状態 $x_0\\in\\{0,1\\}$ 上で解析します。すると、$\\lvert x_0\\rangle$ は次のようになります（ここでは計算を簡単にするために、正規化は無視します）。\n",
+    "+ $H$: $\\lvert 0\\rangle + e^{\\pi i x_0}\\lvert 1\\rangle$,\n",
+    "+ $R_2$: $\\lvert 0\\rangle + e^{\\pi i x_0 + \\frac{2\\pi i x_1}{2^2}}\\lvert 1\\rangle$\n",
+    "+ $R_3$: $\\lvert 0\\rangle + e^{\\pi i x_0 + \\frac{2\\pi i x_1}{2^2} + \\frac{2\\pi i x_2}{2^3}}\\lvert 1\\rangle$\n",
+    "+ $R_4$: $\\lvert 0\\rangle + e^{\\pi i x_0 + \\frac{2\\pi i x_1}{2^2} + \\frac{2\\pi i x_2}{2^3} + \\frac{2\\pi i x_3}{2^4}}\\lvert 1\\rangle = \\lvert 0\\rangle + e^{\\frac{2\\pi i}{2^4} (8x_0 + 4x_1 + 2x_2 + x_3)}\\lvert 1\\rangle = |0\\rangle + e^{\\frac{2\\pi i x}{2^4}}\\lvert 1\\rangle$.\n",
     "\n",
-    "$$QFT(\\mid x_1,x_2,…,x_n \\rangle) = \\frac{1}{\\sqrt{N}}(\\mid 0 \\rangle + e^{2\\pi i [0.x_n]} \\mid 1 \\rangle) \\otimes … \\otimes (\\mid 0 \\rangle + e^{2\\pi i [0.x_1x_2…x_n]} \\mid 1 \\rangle)$$\n",
+    "よって、$\\lvert \\varphi_1\\rangle = \\left(\\lvert 0\\rangle + e^{\\frac{2\\pi i x}{2^4}}\\lvert 1\\rangle\\right)\\otimes \\lvert x_1x_2x_3\\rangle$ となります。\n",
     "\n",
-    "位相にビットが現れた状態での量子状態が得られます。ここで注意したいのは、各量子状態の出現確率は確率振幅の二乗で表せられますが、どの量子状態も出現確率は同一なので測定を通じて位相が得られない点です。"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "yd5MaoRKCuWS"
-   },
-   "source": [
-    "## 量子回路の実装\n",
-    "一番簡単な回路は２量子ビットです。\n",
+    "帰納的に、$\\lvert \\varphi_2\\rangle$ が量子ビット $\\lvert x_1\\rangle$ の状態を次のように変えることが簡単に確かめられます。\n",
+    "+ $\\lvert 0\\rangle + e^{\\frac{2\\pi i}{2^3}(4x_1 + 2x_2 + x_3)}\\lvert 1\\rangle$.  \n",
     "\n",
-    "<img src=\"./img/013_algo_qft01.png\">"
+    "ただし、$e^{2\\pi ix_0} = 1$ なので、$e^{\\frac{2\\pi i}{2^3}(4x_1 + 2x_2 + x_3)}=e^{\\frac{2\\pi i}{2^3}(8x_0 + 4x_1 + 2x_2 + x_3)}= e^{\\frac{2\\pi ix}{2^3}}$ とできます。\n",
+    "\n",
+    "よって $\\lvert \\varphi_2\\rangle = \\left(\\lvert 0\\rangle + e^{\\frac{2\\pi i x}{2^4}}\\lvert 1\\rangle\\right)\\otimes \\left(\\lvert 0\\rangle + e^{\\frac{2\\pi i x}{2^3}}\\lvert 1\\rangle\\right)\\otimes \\lvert x_2x_3\\rangle$ となります。\n",
+    "\n",
+    "このように続けると、 $\\lvert \\varphi_4 \\rangle$ は私達が求める量子ビットを逆の順序で与えることが確認できます。そのため2つのスワップ操作を行って、QFTの回路を完成させました。\n",
+    "\n",
+    "## Blueqat によるQFTの実装"
    ]
   },
   {
@@ -88,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 1,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -98,24 +140,67 @@
     "id": "3eRpgppa_1FI",
     "outputId": "d638cc92-9486-43bc-c94a-14a65c6705d7"
    },
+   "outputs": [],
+   "source": [
+    "# モジュールをインポート\n",
+    "from blueqat import Circuit\n",
+    "import math"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# qftを作用させる関数\n",
+    "def apply_qft(circuit: Circuit(), qubits):\n",
+    "    num_qubits = len(qubits)\n",
+    "    for i in range(num_qubits):\n",
+    "        circuit.h[qubits[i]]\n",
+    "        for j in range(i+1, num_qubits):\n",
+    "            circuit.cphase(math.pi/(2 ** (j-i)))[qubits[j],qubits[i]] # Apply gate CR_{j-i}(qubit j, qubit i)\n",
+    "    # 最後に量子ビットの順序を逆にする\n",
+    "    for i in range(int(num_qubits/2)):\n",
+    "        circuit.swap(qubits[i],qubits[num_qubits-i-1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 回路の実行"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([ 5.00000000e-01+0.j , -8.32667268e-17-0.5j, -5.00000000e-01+0.j ,\n",
-       "        8.32667268e-17+0.5j])"
+       "array([ 2.50000000e-01+0.j        ,  2.30969883e-01-0.09567086j,\n",
+       "        1.76776695e-01-0.1767767j ,  9.56708581e-02-0.23096988j,\n",
+       "       -1.53080850e-17-0.25j      , -9.56708581e-02-0.23096988j,\n",
+       "       -1.76776695e-01-0.1767767j , -2.30969883e-01-0.09567086j,\n",
+       "       -2.50000000e-01+0.j        , -2.30969883e-01+0.09567086j,\n",
+       "       -1.76776695e-01+0.1767767j , -9.56708581e-02+0.23096988j,\n",
+       "        1.53080850e-17+0.25j      ,  9.56708581e-02+0.23096988j,\n",
+       "        1.76776695e-01+0.1767767j ,  2.30969883e-01+0.09567086j])"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "from blueqat import Circuit\n",
-    "import math\n",
-    "\n",
-    "Circuit().x[0,1].h[0].crz(math.pi/2)[1,0].h[1].run()"
+    "n = 4  # QFTを行う量子ビット数\n",
+    "qc = Circuit()\n",
+    "qc.x[:]  # 状態 |1111> を用意\n",
+    "apply_qft(qc, range(n))\n",
+    "qc.run()"
    ]
   },
   {
@@ -125,187 +210,22 @@
     "id": "JM9lexiT_034"
    },
    "source": [
-    "つぎにN=4です。\n",
-    "<img src=\"./img/013_algo_qft02.png\">"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([ 2.50000000e-01+6.93889390e-18j,  2.30969883e-01-9.56708581e-02j,\n",
-       "        1.76776695e-01-1.76776695e-01j,  9.56708581e-02-2.30969883e-01j,\n",
-       "       -5.55111512e-17-2.50000000e-01j, -9.56708581e-02-2.30969883e-01j,\n",
-       "       -1.76776695e-01-1.76776695e-01j, -2.30969883e-01-9.56708581e-02j,\n",
-       "       -2.50000000e-01-6.93889390e-18j, -2.30969883e-01+9.56708581e-02j,\n",
-       "       -1.76776695e-01+1.76776695e-01j, -9.56708581e-02+2.30969883e-01j,\n",
-       "        5.55111512e-17+2.50000000e-01j,  9.56708581e-02+2.30969883e-01j,\n",
-       "        1.76776695e-01+1.76776695e-01j,  2.30969883e-01+9.56708581e-02j])"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "Circuit().x[:].h[0].crz(math.pi/2)[1,0].crz(math.pi/4)[2,0].crz(math.pi/8)[3,0].h[1].crz(math.pi/2)[2,1].crz(math.pi/4)[3,1].h[2].crz(math.pi/2)[3,2].h[3].run()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "_7OgXLuHA3C0"
-   },
-   "source": [
-    "このように、実際にコードを用いて簡単に行うことができました。こちらが量子フーリエ変換です。\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "qdBTsGLnDBce"
-   },
-   "source": [
-    "## （応用）確かめ\n",
-    "量子フーリエ変換は量子状態を直接観測できないので、使いどころが難しいです。そのため最初はシミュレータで状態ベクトルを取得して、既存の高速フーリエ変換FFTと比較するのが良いでしょう。高速フーリエ変換はPythonの一般的なライブラリのNumpyに収録されていて確認ができます。"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 101,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "4VAuNlz1A079",
-    "outputId": "9a8114a5-66e6-4d52-99a0-d1f47d13b8b2"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[ 0.5+0.j   0. +0.5j -0.5+0.j   0. -0.5j]\n"
-     ]
-    }
-   ],
-   "source": [
-    "import numpy as np\n",
-    "print(np.fft.fft(np.array([0,0,0,1])/2)) "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "36753dDzA83S"
-   },
-   "source": [
-    "このようにビットを入力することで、実際に量子フーリエ変換における状態ベクトルからの値と比べて確認をすることができます。上記は最初の二量子ビットの状態と対応していることが確認できます。ビットは状態ベクトルの形に直す必要があるので、1,1のビットは0001と表現されます。以上です。"
+    "QFTは個々の量子ビットの位相を変化させるだけなので、測定によって物理的に観測することはできません。以下は、$\\text{QFT}(|1111\\rangle)$から得られた上記の状態ベクトルを視覚的に表したものです。\n",
+    "\n",
+    "![Statevector](../tutorial/img/121_qft_statevec.png)\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 概要\n",
+    "## QFTの応用\n",
     "\n",
-    "## 離散フーリエ変換\n",
-    "関数を三角関数の和で書き直すためにフーリエ変換というものを使います。   \n",
-    "具体的に言うと三角関数の和で書き直したとき、各三角関数の角振動数とその係数を取り出すということをします。\n",
+    "QFT has wide applications in Algorithms design, and is the building block for many influential quantum algorithms such as Quantum Phase Estimation [[1]] , Shor's Algorithm [[2]], and the Hidden Subgroup Problem [[3]].\n",
     "\n",
-    "例えば sin2x なら 2, 1 を取り出すという操作です。\n",
-    "sinx + sin3x なら 1, 1 と 3, 1 を取り出す操作です。\n",
-    "\n",
-    "このフーリエ変換は全ての点を考えるのに対し有限個の点のみで考えるフーリエ変換を離散フーリエ変換と言います。\n",
-    "\n",
-    "例えば 5sin2x を考えます。これは離散フーリエ変換をすると 5, 2 が取り出せることがわかります。具体的に計算してみます。\n",
-    "\n",
-    "このグラフは以下のようになります。\n",
-    "\n",
-    "<img src=\"https://qiita-user-contents.imgix.net/https%3A%2F%2Fqiita-image-store.s3.ap-northeast-1.amazonaws.com%2F0%2F517405%2Fecd93d6d-11d6-0418-2a35-2100383acd06.png?ixlib=rb-1.2.2&auto=format&gif-q=60&q=75&s=7ae37421c295692ee627c3e12dba1a83\">\n",
-    "\n",
-    "これを16分割で離散フーリエ変換します。\n",
-    "\n",
-    "<img src=\"https://qiita-user-contents.imgix.net/https%3A%2F%2Fqiita-image-store.s3.ap-northeast-1.amazonaws.com%2F0%2F517405%2Fc9fa7740-e50a-9661-979d-d9819b7776dc.png?ixlib=rb-1.2.2&auto=format&gif-q=60&q=75&s=5ddaf7e32081a85c6d1c7b04271de027\">\n",
-    "\n",
-    "各点の y 座標を $x_j$ と置くと\n",
-    "\n",
-    "<img src=\"./img/013_02/013_02_0.png\" width=\"15%\">\n",
-    "\n",
-    "となります。\n",
-    "\n",
-    "これを離散フーリエ変換すると\n",
-    "\n",
-    "<img src=\"./img/013_02/013_02_1.png\" width=\"40%\">\n",
-    "\n",
-    "となるので $|y_k|/2$ のグラフをかくと\n",
-    "\n",
-    "<img src=\"https://qiita-user-contents.imgix.net/https%3A%2F%2Fqiita-image-store.s3.ap-northeast-1.amazonaws.com%2F0%2F517405%2F803b4786-3773-5146-b1db-32a017ea43f2.png?ixlib=rb-1.2.2&auto=format&gif-q=60&q=75&s=e86a155a4bdd33073d1a530f1bad2416\">\n",
-    "\n",
-    "上のグラフは振動数 2、 振幅 5 なのできちんと表せることがわかります。"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 量子フーリエ変換\n",
-    "次に離散フーリエ変換から量子フーリエ変換を考えます。\n",
-    "上の各 $x_j$ を各ビットに埋め込むことを考えます。\n",
-    "\n",
-    "すなわち入力する状態を以下のようにします。\n",
-    "\n",
-    "<img src=\"./img/013_02/013_02_2.png\" width=\"15%\">\n",
-    "\n",
-    "この $x_j$ を離散フーリエ変換すると\n",
-    "\n",
-    "<img src=\"./img/013_02/013_02_3.png\" width=\"20%\">\n",
-    "\n",
-    "となる。また、y について\n",
-    "\n",
-    "<img src=\"./img/013_02/013_02_4.png\" width=\"15%\">\n",
-    "\n",
-    "と置くと、\n",
-    "\n",
-    "<img src=\"./img/013_02/013_02_5.png\" width=\"30%\">\n",
-    "\n",
-    "括弧の部分に注目して以下の変換\n",
-    "\n",
-    "<img src=\"./img/013_02/013_02_6.png\" width=\"25%\">\n",
-    "\n",
-    "のことを量子フーリエ変換と言います。"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 回路の作成\n",
-    "上の式をゲートで実装するために以下のように式を変換します。\n",
-    "\n",
-    "<img src=\"./img/013_02/013_02_7.png\" width=\"85%\">\n",
-    "\n",
-    "回路は以下のようになります。\n",
-    "\n",
-    "<img src=\"./img/013_02/013_02_8.png\" width=\"85%\">\n",
-    "\n",
-    "j を量子フーリエ変換する場合は j を 2進数表示した $j=i_1...i_n$ を入力とします。\n",
-    "また Rn は以下の位相ゲートとします。\n",
-    "\n",
-    "<img src=\"./img/013_02/013_02_9.png\" width=\"15%\">\n",
-    "\n",
-    "以上の回路で量子フーリエ変換を実装できます。"
+    "[1]: https://en.wikipedia.org/wiki/Quantum_phase_estimation_algorithm\n",
+    "[2]: https://en.wikipedia.org/wiki/Shor's_algorithm\n",
+    "[3]: https://en.wikipedia.org/wiki/Hidden_subgroup_problem"
    ]
   },
   {
@@ -324,9 +244,9 @@
    "version": "0.3.2"
   },
   "kernelspec": {
-   "display_name": "conda_python3",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda_python3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -338,7 +258,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/tutorial/121_qft_en.ipynb
+++ b/tutorial/121_qft_en.ipynb
@@ -16,7 +16,7 @@
     "\n",
     "The quantum Fourier transform (commonly abbreviated as QFT) on $n$ qubits (with $N=2^n$), achieves an analogous effect, and is given by the following equation (for every basis state $x\\in\\{0,1\\}^n$):\n",
     "\n",
-    "$$\\text{QFT}(|x\\rangle) = \\frac 1{\\sqrt N}\\sum_{y=0}^{N-1}e^{\\frac{2\\pi ixy}N}|y\\rangle\\qquad \\qquad (1)$$\n",
+    "$$\\text{QFT}(\\lvert x\\rangle) = \\frac 1{\\sqrt N}\\sum_{y=0}^{N-1}e^{\\frac{2\\pi ixy}N}\\lvert y\\rangle\\qquad \\qquad (1)$$\n",
     "\n",
     "Here, we abuse notation and associate a bitstring $x\\in\\{0,1\\}^n$ to the integer $\\sum_{j=0}^{n-1}2^{n-1-j}x_j$.\n",
     "\n",
@@ -34,23 +34,23 @@
     "\n",
     "It turns out (after some algebraic manipulations) that one is able to factorize the sum in Eq. $(1)$ into a product of pure states\n",
     "\n",
-    "$$\\text{QFT}(|x\\rangle) = \\frac 1{\\sqrt N}\\left(|0\\rangle + e^{\\frac{2\\pi ix}{2^1}}|1\\rangle\\right)\\otimes \\left(|0\\rangle + e^{\\frac{2\\pi ix}{2^2}}|1\\rangle\\right)\\otimes \\cdots \\otimes \\left(|0\\rangle + e^{\\frac{2\\pi ix}{2^n}}|1\\rangle\\right).$$\n",
+    "$$\\text{QFT}(\\lvert x\\rangle) = \\frac 1{\\sqrt N}\\left(\\vert 0\\rangle + e^{\\frac{2\\pi ix}{2^1}}\\vert 1\\rangle\\right)\\otimes \\left(\\vert 0\\rangle + e^{\\frac{2\\pi ix}{2^2}}\\vert 1\\rangle\\right)\\otimes \\cdots \\otimes \\left(\\vert 0\\rangle + e^{\\frac{2\\pi ix}{2^n}}\\vert 1\\rangle\\right).$$\n",
     "\n",
     "This formulation tells us exactly how to implement a quantum circuit achieving QFT.\n",
     "\n",
     "## Controlled Phase Rotations\n",
     "Before looking at the circuit structure though, we define the gate\n",
-    "$$R_k = \\begin{bmatrix}1 & 0\\\\ 0 & e^{\\frac{2\\pi i}{2^k}}\\end{bmatrix},$$\n",
+    "$$R_k = \\begin{pmatrix}1 & 0\\\\ 0 & e^{\\frac{2\\pi i}{2^k}}\\end{pmatrix},$$\n",
     "and recall that a controlled version of this gate will change the phase of the target qubit depending on the value of the control qubit.\n",
-    "In other words, $CR_k(|0\\rangle|x\\rangle) = |0\\rangle|x\\rangle$ and \n",
+    "In other words, $CR_k(\\lvert 0\\rangle|x\\rangle) = |0\\rangle \\lvert x\\rangle$ and \n",
     "\n",
-    "\\begin{aligned}CR_k(|1\\rangle |x\\rangle) = |1\\rangle\\otimes R_k(|x \\rangle) &=|1\\rangle\\otimes R_k\\left( \\langle 0|x\\rangle| 0\\rangle + \\langle 1|x\\rangle |1\\rangle\\right)\n",
-    " \\\\ & = |1\\rangle\\otimes \\left( \\langle 0|x\\rangle| 0\\rangle + \\langle 1|x\\rangle e^{\\frac{2\\pi i}{2^k}}|1\\rangle\\right)\\end{aligned}\n",
+    "\\begin{aligned}CR_k(\\lvert 1\\rangle \\lvert x\\rangle) = \\lvert 1\\rangle\\otimes R_k(\\lvert x \\rangle) &=\\lvert 1\\rangle\\otimes R_k\\left( \\langle 0\\lvert x\\rangle \\lvert  0\\rangle + \\langle 1 \\lvert x\\rangle \\lvert 1\\rangle\\right)\n",
+    " \\\\ & = \\lvert 1\\rangle\\otimes \\left( \\langle 0 \\lvert x\\rangle \\lvert  0\\rangle + \\langle 1 \\lvert x\\rangle e^{\\frac{2\\pi i}{2^k}} \\lvert 1\\rangle\\right)\\end{aligned}\n",
     "\n",
     "More compactly,\n",
-    "$$CR_k(|y\\rangle|x\\rangle) = |y\\rangle \\otimes \\left( \\langle 0|x\\rangle| 0\\rangle + \\langle 1|x\\rangle e^{\\frac{2\\pi iy}{2^k}}|1\\rangle\\right).$$\n",
+    "$$CR_k(\\lvert y\\rangle \\lvert x\\rangle) = \\lvert y\\rangle \\otimes \\left( \\langle 0 \\vert x\\rangle \\lvert  0\\rangle + \\langle 1 \\vert x\\rangle e^{\\frac{2\\pi iy}{2^k}} \\lvert 1\\rangle\\right).$$\n",
     "\n",
-    "Therefore, $$CR_k = \\begin{bmatrix}1 & 0 & 0 & 0\\\\ 0 & 1 & 0 & 0\\\\ 0& 0& 1 & 0\\\\ 0 & 0&0 &e^{\\frac{2\\pi i}{2^k}}\\end{bmatrix} = \\text{CPhase}\\left(\\frac{2\\pi}{2^k}\\right).$$"
+    "Therefore, $$CR_k = \\begin{pmatrix}1 & 0 & 0 & 0\\\\ 0 & 1 & 0 & 0\\\\ 0& 0& 1 & 0\\\\ 0 & 0&0 &e^{\\frac{2\\pi i}{2^k}}\\end{pmatrix} = \\text{CPhase}\\left(\\frac{2\\pi}{2^k}\\right).$$"
    ]
   },
   {
@@ -67,7 +67,7 @@
     "\n",
     "![Circuit Image](img/121_qft_ckt.png)\n",
     "\n",
-    "We shall work our way through the states $|\\varphi_1\\rangle$ through $|\\varphi_4\\rangle$.\n"
+    "We shall work our way through the states $\\lvert \\varphi_1\\rangle$ through $\\lvert \\varphi_4\\rangle$.\n"
    ]
   },
   {
@@ -77,20 +77,22 @@
     "id": "yd5MaoRKCuWS"
    },
    "source": [
-    "In $|\\varphi_1\\rangle$, let us analyze the state of the first qubit on the basis states $x_0\\in\\{0,1\\}$. Then $|x_0\\rangle$ is mapped to (let us ignore normalizations for simplifying calculations):\n",
-    "+ $H$: $|0\\rangle + e^{\\pi i x_0}|1\\rangle$,\n",
-    "+ $R_2$: $|0\\rangle + e^{\\pi i x_0 + \\frac{2\\pi i x_1}{2^2}}|1\\rangle$\n",
-    "+ $R_3$: $|0\\rangle + e^{\\pi i x_0 + \\frac{2\\pi i x_1}{2^2} + \\frac{2\\pi i x_2}{2^3}}|1\\rangle$\n",
-    "+ $R_4$: $|0\\rangle + e^{\\pi i x_0 + \\frac{2\\pi i x_1}{2^2} + \\frac{2\\pi i x_2}{2^3} + \\frac{2\\pi i x_3}{2^4}}|1\\rangle = |0\\rangle + e^{\\frac{2\\pi i}{2^4} (8x_0 + 4x_1 + 2x_2 + x_3)}|1\\rangle = |0\\rangle + e^{\\frac{2\\pi i x}{2^4}}|1\\rangle$.\n",
+    "In $\\lvert \\varphi_1\\rangle$, let us analyze the state of the first qubit on the basis states $x_0\\in\\{0,1\\}$. Then $\\lvert x_0\\rangle$ is mapped to (let us ignore normalizations for simplifying calculations):\n",
+    "+ $H$: $\\lvert 0\\rangle + e^{\\pi i x_0}\\lvert 1\\rangle$,\n",
+    "+ $R_2$: $\\lvert 0\\rangle + e^{\\pi i x_0 + \\frac{2\\pi i x_1}{2^2}}\\lvert 1\\rangle$\n",
+    "+ $R_3$: $\\lvert 0\\rangle + e^{\\pi i x_0 + \\frac{2\\pi i x_1}{2^2} + \\frac{2\\pi i x_2}{2^3}}\\lvert 1\\rangle$\n",
+    "+ $R_4$: $\\lvert 0\\rangle + e^{\\pi i x_0 + \\frac{2\\pi i x_1}{2^2} + \\frac{2\\pi i x_2}{2^3} + \\frac{2\\pi i x_3}{2^4}}\\lvert 1\\rangle = \\lvert 0\\rangle + e^{\\frac{2\\pi i}{2^4} (8x_0 + 4x_1 + 2x_2 + x_3)}\\lvert 1\\rangle = |0\\rangle + e^{\\frac{2\\pi i x}{2^4}}\\lvert 1\\rangle$.\n",
     "\n",
-    "Hence, $|\\varphi_1\\rangle = \\left(|0\\rangle + e^{\\frac{2\\pi i x}{2}}|1\\rangle\\right)\\otimes |x_1x_2x_3\\rangle$.\n",
+    "Hence, $\\lvert \\varphi_1\\rangle = \\left(\\lvert 0\\rangle + e^{\\frac{2\\pi i x}{2^4}}\\lvert 1\\rangle\\right)\\otimes \\lvert x_1x_2x_3\\rangle$.\n",
     "\n",
-    "It is now easy to see via an inductive argument that $|\\varphi_2\\rangle$ changes qubit $|x_1\\rangle$ to:\n",
-    "+ $|0\\rangle + e^{\\frac{2\\pi i}{2^3}(4x_1 + 2x_2 + x_3)}|1\\rangle$. However, as $e^{2\\pi ix_0} = 1$, we have $e^{\\frac{2\\pi i}{2^3}(4x_1 + 2x_2 + x_3)}=e^{\\frac{2\\pi i}{2^3}(8x_0 + 4x_1 + 2x_2 + x_3)}= e^{\\frac{2\\pi ix}{2^3}}$.\n",
+    "It is now easy to see via an inductive argument that $\\lvert \\varphi_2\\rangle$ changes qubit $\\lvert x_1\\rangle$ to:\n",
+    "+ $\\lvert 0\\rangle + e^{\\frac{2\\pi i}{2^3}(4x_1 + 2x_2 + x_3)}\\lvert 1\\rangle$.  \n",
     "\n",
-    "So, $|\\varphi_2\\rangle = \\left(|0\\rangle + e^{\\frac{2\\pi i x}{2^4}}|1\\rangle\\right)\\otimes \\left(|0\\rangle + e^{\\frac{2\\pi i x}{2^3}}|1\\rangle\\right)\\otimes |x_2x_3\\rangle$.\n",
+    "However, as $e^{2\\pi ix_0} = 1$, we have $e^{\\frac{2\\pi i}{2^3}(4x_1 + 2x_2 + x_3)}=e^{\\frac{2\\pi i}{2^3}(8x_0 + 4x_1 + 2x_2 + x_3)}= e^{\\frac{2\\pi ix}{2^3}}$.\n",
     "\n",
-    "Continuing, we can check that $\\varphi_4$ gives us the reverse order of the qubits that we wanted, and hence we do a double swap to complete the circuit schematic of QFT.\n",
+    "So, $\\lvert \\varphi_2\\rangle = \\left(\\lvert 0\\rangle + e^{\\frac{2\\pi i x}{2^4}}\\lvert 1\\rangle\\right)\\otimes \\left(\\lvert 0\\rangle + e^{\\frac{2\\pi i x}{2^3}}\\lvert 1\\rangle\\right)\\otimes \\lvert x_2x_3\\rangle$.\n",
+    "\n",
+    "Continuing, we can check that $\\vert \\varphi_4 \\rangle$ gives us the reverse order of the qubits that we wanted, and hence we do a double swap to complete the circuit schematic of QFT.\n",
     "\n",
     "## Writing QFT in Blueqat-SDK"
    ]
@@ -225,6 +227,13 @@
     "[2]: https://en.wikipedia.org/wiki/Shor's_algorithm\n",
     "[3]: https://en.wikipedia.org/wiki/Hidden_subgroup_problem"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -249,7 +258,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.2"
   },
   "pycharm": {
    "stem_cell": {


### PR DESCRIPTION
I translated the new version of QFT tutorial (121_qft_en) to Japanese.
I made a little change to English version, such as notations ("bmatrix" to "pmatrix", "|" to "\lvert").