### PR TITLE
np.int-->np.int64

### DIFF
--- a/tutorial/103_simon.ipynb
+++ b/tutorial/103_simon.ipynb
@@ -326,7 +326,7 @@
     "    l = bin(i)[2:].zfill(n)\n",
     "    flag = 1\n",
     "    for sampled in _res_list: \n",
-    "        mod = np.sum(np.array(list(l), dtype = np.int) * np.array(list(sampled), dtype = np.int)) % 2\n",
+    "        mod = np.sum(np.array(list(l), dtype = np.int64) * np.array(list(sampled), dtype = np.int64)) % 2\n",
     "        if mod:\n",
     "            flag = 0\n",
     "            break\n",


### PR DESCRIPTION
DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  mod = np.sum(np.array(list(l), dtype = np.int) * np.array(list(sampled), dtype = np.int)) % 2