### PR TITLE
Add "Shor's Algorithm from Scratch" tutorial series (Part 1-2)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -58,6 +58,16 @@ English version is available at [README.md](README.md).
 |310.|<a href="tutorial/ja/310_shor.ipynb">ショアのアルゴリズム</a>|
 |311.|<a href="tutorial/ja/311_four.ipynb">四則演算と剰余</a>|
 
+3-2. ゼロから作るショアのアルゴリズム(本格実装、順次追加中)
+--------------------
+
+上記310の関連シリーズです。ショアのアルゴリズムの実際に動く実装を、算術演算の部品から少しずつ積み上げていきます。準備ができ次第、続きを追加していきます。
+
+|No.|タイトル|
+|:---|:---|
+|320.|<a href="tutorial/ja/320_shor_scratch_adder.ipynb">第1回: 量子加算器</a>|
+|321.|<a href="tutorial/ja/321_shor_scratch_modulo_adder.ipynb">第2回: 剰余加算器</a>|
+
 Contributors
 ----------
 <a href="https://github.com/Blueqat/Blueqat-tutorials/graphs/contributors" target="_blank">Contributors</a>

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ pip install git+https://github.com/blueqat/blueqatSDK
 |310.|<a href="tutorial/310_shor.ipynb">Shor's algorithm</a>|<a href="tutorial/ja/310_shor.ipynb">日本語</a>|
 |311.|<a href="tutorial/311_four.ipynb">Four Calculations and Modulus</a>|<a href="tutorial/ja/311_four.ipynb">日本語</a>|
 
+3-2. Shor's Algorithm from Scratch (full implementation, work in progress)
+--------------------
+
+A companion series to 310 above, building a working implementation of Shor's algorithm from the ground up, one arithmetic building block at a time. More parts will be added as they're ready.
+
+|No.|Title|日本語|
+|:---|:---|:---|
+|320.|<a href="tutorial/320_shor_scratch_adder.ipynb">Part 1: Quantum Adder</a>|<a href="tutorial/ja/320_shor_scratch_adder.ipynb">日本語</a>|
+|321.|<a href="tutorial/321_shor_scratch_modulo_adder.ipynb">Part 2: Modulo Adder</a>|<a href="tutorial/ja/321_shor_scratch_modulo_adder.ipynb">日本語</a>|
+
 Contributors
 ----------
 <a href="https://github.com/Blueqat/Blueqat-tutorials/graphs/contributors" target="_blank">Contributors</a>

--- a/tutorial/310_shor.ipynb
+++ b/tutorial/310_shor.ipynb
@@ -588,6 +588,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "6a90ad21",
+   "metadata": {},
+   "source": [
+    "**Want a full working implementation, not just the theory?** A companion series builds Shor's algorithm up from scratch, one arithmetic building block at a time, starting with a [quantum adder](320_shor_scratch_adder.ipynb) and [modulo adder](321_shor_scratch_modulo_adder.ipynb) (more parts added as they're ready)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorial/320_shor_scratch_adder.ipynb
+++ b/tutorial/320_shor_scratch_adder.ipynb
@@ -1,0 +1,291 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7a76945b",
+   "metadata": {},
+   "source": [
+    "# Building Shor's Algorithm from Scratch, Part 1: The Quantum Adder\n",
+    "\n",
+    "[Another tutorial](310_shor.ipynb) in this collection already walks through the *theory* of Shor's algorithm end to end. This is the start of a companion series that builds a **working implementation** up from first principles, one arithmetic building block at a time: quantum adder → modulo adder → controlled modular multiplier → modular exponentiation → the full algorithm. Each part will be added as it's ready.\n",
+    "\n",
+    "This tutorial covers the first, most basic piece: a quantum circuit that adds two binary numbers.\n",
+    "\n",
+    "Reference: V. Vedral, A. Barenco, A. Ekert, [\"Quantum Networks for Elementary Arithmetic Operations\"](https://arxiv.org/abs/quant-ph/9511018) (1995)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3f06543",
+   "metadata": {},
+   "source": [
+    "## Why an adder?\n",
+    "\n",
+    "Recall the shape of Shor's algorithm (see [310_shor.ipynb](310_shor.ipynb) for the full derivation): the quantum part finds the *order* $r$ of some $x$ modulo $N$, i.e. the smallest $r$ with $x^r \\equiv 1 \\pmod N$. Finding $r$ boils down to computing $x^j \\bmod N$ in superposition over many values of $j$ at once — **modular exponentiation**. Modular exponentiation is built out of repeated **controlled modular multiplication**, which is itself built out of repeated **modular addition**. So the very bottom of the stack is: how do you add two numbers on a quantum computer?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2fcaf3a",
+   "metadata": {},
+   "source": [
+    "## From classical gates to quantum gates\n",
+    "\n",
+    "Three quantum gates are enough to reproduce any classical (reversible) logic:\n",
+    "\n",
+    "| Classical operation | Quantum gate |\n",
+    "|:---|:---|\n",
+    "| NOT | `X` |\n",
+    "| XOR | `CX` (CNOT) |\n",
+    "| AND | `CCX` (Toffoli) |\n",
+    "\n",
+    "`CX[a, b]` flips qubit `b` if qubit `a` is `1` — that's exactly `b := b XOR a`. `CCX[a, b, c]` flips `c` only when *both* `a` and `b` are `1` — that's `c := c OR (a AND b)` when `c` starts at `0`. Ordinary binary addition of two bits is built from exactly these two operations: a carry-out bit is the AND of the inputs (plus the incoming carry), and the sum bit is the XOR of the inputs (plus the incoming carry)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c670a607",
+   "metadata": {},
+   "source": [
+    "## CARRY and SUM\n",
+    "\n",
+    "For one bit position, with incoming carry $c$, addends $a$, $b$, and outgoing carry $c_{next}$:\n",
+    "\n",
+    "```\n",
+    "CARRY: c,a,b,c_next -> c,a,b, c_next XOR (carry-out of a+b+c)\n",
+    "SUM:   c,a,b         -> c,a, (a XOR b XOR c)\n",
+    "```\n",
+    "\n",
+    "Chaining `CARRY` from the least significant bit upward produces every carry bit; `SUM` then turns each carry into the corresponding sum bit. Because quantum gates must be reversible, `CARRY` and `SUM` are literally just circuits made of `CCX`/`CX`, so they're automatically invertible — we'll need `CARRY`'s inverse (`CARRY_INV`) further down."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4ed2c2c4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T05:36:48.937571Z",
+     "iopub.status.busy": "2026-07-13T05:36:48.937263Z",
+     "iopub.status.idle": "2026-07-13T05:36:49.182553Z",
+     "shell.execute_reply": "2026-07-13T05:36:49.181638Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/yuichirominato/.pyenv/shims/pip: line 8: /opt/homebrew/opt/pyenv/bin/pyenv: No such file or directory\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install git+https://github.com/blueqat/blueqatSDK"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "4e48dc71",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T05:36:49.184620Z",
+     "iopub.status.busy": "2026-07-13T05:36:49.184428Z",
+     "iopub.status.idle": "2026-07-13T05:36:49.728434Z",
+     "shell.execute_reply": "2026-07-13T05:36:49.727728Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from blueqat import Circuit\n",
+    "\n",
+    "def carry(c, a, b, c_next):\n",
+    "    \"\"\"CCX[a,b,c_next].CX[a,b].CCX[c,b,c_next] -- propagates the carry out of bit position a+b+c into c_next.\"\"\"\n",
+    "    circ = Circuit()\n",
+    "    circ.ccx[a, b, c_next]\n",
+    "    circ.cx[a, b]\n",
+    "    circ.ccx[c, b, c_next]\n",
+    "    return circ\n",
+    "\n",
+    "def carry_inv(c, a, b, c_next):\n",
+    "    \"\"\"The inverse of carry(): same three (self-inverse) gates, applied in reverse order.\"\"\"\n",
+    "    circ = Circuit()\n",
+    "    circ.ccx[c, b, c_next]\n",
+    "    circ.cx[a, b]\n",
+    "    circ.ccx[a, b, c_next]\n",
+    "    return circ\n",
+    "\n",
+    "def sum_gate(c, a, b):\n",
+    "    \"\"\"CX[a,b].CX[c,b] -- turns b into a XOR b XOR c (the sum bit), leaving a and c unchanged.\"\"\"\n",
+    "    circ = Circuit()\n",
+    "    circ.cx[a, b]\n",
+    "    circ.cx[c, b]\n",
+    "    return circ"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "243d2fcb",
+   "metadata": {},
+   "source": [
+    "## Assembling the full adder\n",
+    "\n",
+    "To add two $n$-bit numbers $a$ and $b$ we need $3n+1$ qubits, split into three registers:\n",
+    "\n",
+    "- `c[0..n-1]`: carry register, starts at $\\ket{0}$\n",
+    "- `a[0..n-1]`: first addend\n",
+    "- `b[0..n]`: second addend, **one bit wider than the inputs** — the sum $a+b$ can need one extra bit, and this is where the answer ends up\n",
+    "\n",
+    "The circuit runs `carry` from the low bit upward to ripple the carry all the way to the top (into `b[n]`, the extra bit), applies `sum_gate` to the top bit, and then walks back down applying `carry_inv` followed by `sum_gate` at each lower bit — computing every remaining sum bit while simultaneously **uncomputing** the carry register back to all zeros so it can be reused or discarded cleanly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "bb11567a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T05:36:49.729737Z",
+     "iopub.status.busy": "2026-07-13T05:36:49.729638Z",
+     "iopub.status.idle": "2026-07-13T05:36:49.732258Z",
+     "shell.execute_reply": "2026-07-13T05:36:49.731979Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def build_adder(input_a, input_b, n):\n",
+    "    \"\"\"n-bit ripple-carry adder. Returns (circuit, b_register_qubit_indices).\"\"\"\n",
+    "    num_qubits = 3 * n + 1\n",
+    "    circ = Circuit(num_qubits)\n",
+    "\n",
+    "    c = list(range(n))\n",
+    "    a = list(range(n, 2 * n))\n",
+    "    b = list(range(2 * n, 3 * n + 1))\n",
+    "\n",
+    "    # Encode the two inputs (c stays at |0...0>)\n",
+    "    for i in range(n):\n",
+    "        if (input_a >> i) & 1:\n",
+    "            circ.x[a[i]]\n",
+    "        if (input_b >> i) & 1:\n",
+    "            circ.x[b[i]]\n",
+    "\n",
+    "    # Ripple the carry up\n",
+    "    for i in range(n - 1):\n",
+    "        circ += carry(c[i], a[i], b[i], c[i + 1])\n",
+    "    circ += carry(c[n - 1], a[n - 1], b[n - 1], b[n])\n",
+    "\n",
+    "    # Top sum bit\n",
+    "    circ.cx[a[n - 1], b[n - 1]]\n",
+    "    circ += sum_gate(c[n - 1], a[n - 1], b[n - 1])\n",
+    "\n",
+    "    # Walk back down: uncompute the carries, filling in the remaining sum bits\n",
+    "    for i in range(n - 2, -1, -1):\n",
+    "        circ += carry_inv(c[i], a[i], b[i], c[i + 1])\n",
+    "        circ += sum_gate(c[i], a[i], b[i])\n",
+    "\n",
+    "    return circ, b"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "325b420b",
+   "metadata": {},
+   "source": [
+    "## Reading out the answer\n",
+    "\n",
+    "**A note on bit order**: this SDK's `.run(shots=...)` returns bitstrings with qubit 0 as the *rightmost* character (standard binary-string convention), so to read off qubit `q`'s value from a result string of length `N` we index `state[N - 1 - q]`. `b[0]` is the least significant bit of the sum, so we read the `b` register from `b[0]` (least significant) up to `b[n]` (most significant) and assemble the integer accordingly.\n",
+    "\n",
+    "Because this circuit is built entirely from `X`/`CX`/`CCX` — gates that just flip qubits around rather than creating superposition — a single deterministic input always produces a single deterministic output. `shots=1` is enough to get an exact answer every time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1400977a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T05:36:49.733166Z",
+     "iopub.status.busy": "2026-07-13T05:36:49.733089Z",
+     "iopub.status.idle": "2026-07-13T05:36:49.735079Z",
+     "shell.execute_reply": "2026-07-13T05:36:49.734772Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def run_adder(val_a, val_b):\n",
+    "    n = max(val_a, val_b, 1).bit_length()\n",
+    "    circuit, b = build_adder(val_a, val_b, n)\n",
+    "    state = circuit.m[:].run(shots=1).most_common(1)[0][0]\n",
+    "    total_qubits = len(state)\n",
+    "    bits = [state[total_qubits - 1 - q] for q in b]  # bits[0] = LSB\n",
+    "    return int(\"\".join(reversed(bits)), 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "6b071f92",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T05:36:49.735775Z",
+     "iopub.status.busy": "2026-07-13T05:36:49.735715Z",
+     "iopub.status.idle": "2026-07-13T05:36:49.778920Z",
+     "shell.execute_reply": "2026-07-13T05:36:49.778356Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 + 6 = 16  (expected 16, OK)\n",
+      "1 + 1 = 2  (expected 2, OK)\n",
+      "3 + 5 = 8  (expected 8, OK)\n",
+      "7 + 7 = 14  (expected 14, OK)\n",
+      "0 + 5 = 5  (expected 5, OK)\n",
+      "15 + 15 = 30  (expected 30, OK)\n"
+     ]
+    }
+   ],
+   "source": [
+    "for x, y in [(10, 6), (1, 1), (3, 5), (7, 7), (0, 5), (15, 15)]:\n",
+    "    result = run_adder(x, y)\n",
+    "    print(f\"{x} + {y} = {result}  (expected {x + y}, {'OK' if result == x + y else 'MISMATCH'})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d40e8d37",
+   "metadata": {},
+   "source": [
+    "All six cases match ordinary integer addition exactly, as expected for a purely reversible-logic circuit.\n",
+    "\n",
+    "## What's next\n",
+    "\n",
+    "This adder is the innermost building block. The next tutorial in the series adds **modular** addition ($a+b \\bmod N$) on top of it — the actual operation Shor's algorithm needs, since every intermediate value in modular exponentiation has to stay within $[0, N)$."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tutorial/321_shor_scratch_modulo_adder.ipynb
+++ b/tutorial/321_shor_scratch_modulo_adder.ipynb
@@ -1,0 +1,344 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8626fcfd",
+   "metadata": {},
+   "source": [
+    "# Building Shor's Algorithm from Scratch, Part 2: The Modulo Adder\n",
+    "\n",
+    "In [Part 1](320_shor_scratch_adder.ipynb) we built a plain quantum adder. This tutorial builds **modular** addition, $a+b \\bmod N$, on top of it — the operation actually needed inside Shor's algorithm, since every intermediate value produced while computing $x^j \\bmod N$ has to be kept within $[0, N)$.\n",
+    "\n",
+    "Reference: V. Vedral, A. Barenco, A. Ekert, [\"Quantum Networks for Elementary Arithmetic Operations\"](https://arxiv.org/abs/quant-ph/9511018) (1995), Figure 3."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98976d69",
+   "metadata": {},
+   "source": [
+    "## The five-step idea\n",
+    "\n",
+    "$(a+b) \\bmod N$ is easy classically: add, then subtract $N$ if the result is $\\ge N$. On a quantum computer we can't just \"check and branch\" the usual way (that would require measuring, collapsing any superposition we care about) — instead the check has to be done *with a qubit*, and the conditional subtraction has to be done *with a controlled circuit*.\n",
+    "\n",
+    "1. **Add**: $b \\leftarrow a + b$ (using Part 1's adder)\n",
+    "2. **Subtract $N$**: $b \\leftarrow b - N$ (the adder run backwards)\n",
+    "3. **Detect the sign**: if step 2 made $b$ go negative, the adder's extra top qubit ends up as $1$ (it acts like a borrow/overflow flag) — copy that bit into a flag qubit $t$\n",
+    "4. **Conditionally add $N$ back**: if $t=1$ (i.e. $a+b < N$, so subtracting $N$ overshot), add $N$ back — but *only* on the branches of the superposition where $t=1$, using $t$ as an extra control qubit\n",
+    "5. **Clean up**: restore $t$ to $\\ket 0$ and undo the sign-detection step, so the whole thing is a clean, reusable, entangling-free-outside-$b$ operation\n",
+    "\n",
+    "Steps 1-2 use the adder/subtractor directly; step 4 needs a *controlled* version of the whole adder circuit, which is the interesting new piece here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f83c072a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T05:39:59.163628Z",
+     "iopub.status.busy": "2026-07-13T05:39:59.163392Z",
+     "iopub.status.idle": "2026-07-13T05:39:59.403063Z",
+     "shell.execute_reply": "2026-07-13T05:39:59.402237Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/yuichirominato/.pyenv/shims/pip: line 8: /opt/homebrew/opt/pyenv/bin/pyenv: No such file or directory\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install git+https://github.com/blueqat/blueqatSDK"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b42cdce2",
+   "metadata": {},
+   "source": [
+    "## Reusing Part 1's building blocks\n",
+    "\n",
+    "Same `carry`/`carry_inv`/`sum_gate` as before, plus the full adder assembled into `add_circuit`, and its inverse `sub_circuit` obtained simply by running the same gates in reverse order (every gate here is `CX` or `CCX`, both self-inverse, so reversing the *order* is enough — no need to invert any individual gate)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3d2ad912",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T05:39:59.405116Z",
+     "iopub.status.busy": "2026-07-13T05:39:59.404938Z",
+     "iopub.status.idle": "2026-07-13T05:40:00.186630Z",
+     "shell.execute_reply": "2026-07-13T05:40:00.186134Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from blueqat import Circuit\n",
+    "from blueqat.gate import CXGate, ToffoliGate\n",
+    "\n",
+    "def carry(c, a, b, c_next):\n",
+    "    circ = Circuit()\n",
+    "    circ.ccx[a, b, c_next]\n",
+    "    circ.cx[a, b]\n",
+    "    circ.ccx[c, b, c_next]\n",
+    "    return circ\n",
+    "\n",
+    "def carry_inv(c, a, b, c_next):\n",
+    "    circ = Circuit()\n",
+    "    circ.ccx[c, b, c_next]\n",
+    "    circ.cx[a, b]\n",
+    "    circ.ccx[a, b, c_next]\n",
+    "    return circ\n",
+    "\n",
+    "def sum_gate(c, a, b):\n",
+    "    circ = Circuit()\n",
+    "    circ.cx[a, b]\n",
+    "    circ.cx[c, b]\n",
+    "    return circ\n",
+    "\n",
+    "def add_circuit(c, a, b, n):\n",
+    "    \"\"\"b := a + b, using carry register c. b must have n+1 qubits.\"\"\"\n",
+    "    circ = Circuit()\n",
+    "    for i in range(n - 1):\n",
+    "        circ += carry(c[i], a[i], b[i], c[i + 1])\n",
+    "    circ += carry(c[n - 1], a[n - 1], b[n - 1], b[n])\n",
+    "    circ.cx[a[n - 1], b[n - 1]]\n",
+    "    circ += sum_gate(c[n - 1], a[n - 1], b[n - 1])\n",
+    "    for i in range(n - 2, -1, -1):\n",
+    "        circ += carry_inv(c[i], a[i], b[i], c[i + 1])\n",
+    "        circ += sum_gate(c[i], a[i], b[i])\n",
+    "    return circ\n",
+    "\n",
+    "def sub_circuit(c, a, b, n):\n",
+    "    \"\"\"b := b - a: the adder's gate list, reversed.\"\"\"\n",
+    "    add_circ = add_circuit(c, a, b, n)\n",
+    "    reversed_circ = Circuit()\n",
+    "    reversed_circ.ops = list(reversed(add_circ.ops))\n",
+    "    return reversed_circ"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab583895",
+   "metadata": {},
+   "source": [
+    "## Registers\n",
+    "\n",
+    "The full modulo adder needs $4n+3$ qubits:\n",
+    "\n",
+    "- `c[0..n-1]`: carry register (reused for both add and subtract steps)\n",
+    "- `a[0..n-1]`: first addend\n",
+    "- `b[0..n]`: second addend / running result (same $n+1$-wide register as Part 1 — its top bit doubles as the overflow/borrow flag during step 3)\n",
+    "- `N[0..n-1]`: the modulus, loaded as a constant\n",
+    "- `t`: one flag qubit for \"did we need to add $N$ back?\"\n",
+    "- one ancilla qubit, needed only to help build 3-controlled gates below"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "faa33076",
+   "metadata": {},
+   "source": [
+    "## Step 4 in detail: a controlled adder from an uncontrolled one\n",
+    "\n",
+    "We already have `add_circuit(c, N, b, n)` for \"$b \\leftarrow b + N$\" — but step 4 needs to apply it *only when $t=1$*, i.e. a version of every gate in that circuit controlled by $t$. Controlling a `CX` by one more qubit gives a `CCX` — easy. Controlling a `CCX` by one more qubit gives a **3-controlled X**, which isn't a gate this SDK has directly. The standard trick: use one ancilla qubit to compute the AND of the *first two* controls into the ancilla with a `CCX`, apply an ordinary `CCX` using the ancilla as one of its two controls, then uncompute the ancilla back to $\\ket 0$ with the same `CCX` again. Net effect: a `CCX` controlled by one extra qubit, using only 2-control gates and one temporary qubit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "822dfa33",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T05:40:00.187698Z",
+     "iopub.status.busy": "2026-07-13T05:40:00.187595Z",
+     "iopub.status.idle": "2026-07-13T05:40:00.190696Z",
+     "shell.execute_reply": "2026-07-13T05:40:00.190427Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def build_modulo_adder(input_a, input_b, input_N, n):\n",
+    "    \"\"\"b := (a + b) mod N. Returns (circuit, b_register_qubit_indices).\"\"\"\n",
+    "    num_qubits = 4 * n + 3\n",
+    "    circ = Circuit(num_qubits)\n",
+    "\n",
+    "    c = list(range(n))\n",
+    "    a = list(range(n, 2 * n))\n",
+    "    b = list(range(2 * n, 3 * n + 1))\n",
+    "    N = list(range(3 * n + 1, 4 * n + 1))\n",
+    "    t = 4 * n + 1\n",
+    "    ancilla = 4 * n + 2\n",
+    "\n",
+    "    # Encode inputs\n",
+    "    for i in range(n):\n",
+    "        if (input_a >> i) & 1:\n",
+    "            circ.x[a[i]]\n",
+    "        if (input_b >> i) & 1:\n",
+    "            circ.x[b[i]]\n",
+    "        if (input_N >> i) & 1:\n",
+    "            circ.x[N[i]]\n",
+    "\n",
+    "    # Steps 1-2: b <- a + b, then b <- b - N\n",
+    "    circ += add_circuit(c, a, b, n)\n",
+    "    circ += sub_circuit(c, N, b, n)\n",
+    "\n",
+    "    # Step 3: copy the borrow/overflow bit into the flag t\n",
+    "    circ.cx[b[n], t]\n",
+    "\n",
+    "    # Step 4: if t == 1, add N back (t-controlled add_circuit, via the ancilla trick above)\n",
+    "    controlled_add = add_circuit(c, N, b, n)\n",
+    "    for g in controlled_add.ops:\n",
+    "        if isinstance(g, CXGate):\n",
+    "            circ.ccx[t, g.targets[0], g.targets[1]]\n",
+    "        elif isinstance(g, ToffoliGate):\n",
+    "            circ.ccx[t, g.targets[0], ancilla]\n",
+    "            circ.ccx[ancilla, g.targets[1], g.targets[2]]\n",
+    "            circ.ccx[t, g.targets[0], ancilla]\n",
+    "\n",
+    "    # Step 5: clean up -- undo the borrow/overflow detection and reset t to |0>\n",
+    "    circ += sub_circuit(c, a, b, n)\n",
+    "    circ.x[b[n]]\n",
+    "    circ.cx[b[n], t]\n",
+    "    circ.x[b[n]]\n",
+    "    circ += add_circuit(c, a, b, n)\n",
+    "\n",
+    "    return circ, b"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2fa822ca",
+   "metadata": {},
+   "source": [
+    "## Testing it\n",
+    "\n",
+    "Same bit-order convention as Part 1: qubit `q` is `state[N - 1 - q]` in the result string."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "dd54a576",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T05:40:00.191642Z",
+     "iopub.status.busy": "2026-07-13T05:40:00.191585Z",
+     "iopub.status.idle": "2026-07-13T05:40:00.193708Z",
+     "shell.execute_reply": "2026-07-13T05:40:00.193418Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def run_modulo_adder(val_a, val_b, val_N, n):\n",
+    "    circuit, b = build_modulo_adder(val_a, val_b, val_N, n)\n",
+    "    state = circuit.m[:].run(shots=1).most_common(1)[0][0]\n",
+    "    total_qubits = len(state)\n",
+    "    bits = [state[total_qubits - 1 - q] for q in b]  # bits[0] = LSB\n",
+    "    return int(\"\".join(reversed(bits)), 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d40e0786",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T05:40:00.194483Z",
+     "iopub.status.busy": "2026-07-13T05:40:00.194431Z",
+     "iopub.status.idle": "2026-07-13T05:40:14.237712Z",
+     "shell.execute_reply": "2026-07-13T05:40:14.237171Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(7+6) mod 11 = 2  (expected 2, OK)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(14+13) mod 15 = 12  (expected 12, OK)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(3+5) mod 9 = 8  (expected 8, OK)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(0+0) mod 7 = 0  (expected 0, OK)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(5+5) mod 6 = 4  (expected 4, OK)\n"
+     ]
+    }
+   ],
+   "source": [
+    "tests = [\n",
+    "    (7, 6, 11, 4),\n",
+    "    (14, 13, 15, 4),\n",
+    "    (3, 5, 9, 4),\n",
+    "    (0, 0, 7, 3),\n",
+    "    (5, 5, 6, 3),\n",
+    "]\n",
+    "for x, y, N, n in tests:\n",
+    "    result = run_modulo_adder(x, y, N, n)\n",
+    "    expected = (x + y) % N\n",
+    "    print(f\"({x}+{y}) mod {N} = {result}  (expected {expected}, {'OK' if result == expected else 'MISMATCH'})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28174111",
+   "metadata": {},
+   "source": [
+    "All five cases match. Note that a couple of these are chosen to exercise both branches: `(7+6) mod 11` actually needs the subtract-and-add-back correction (`7+6=13 \\ge 11`), while `(0+0) mod 7` never goes negative and step 4 should do nothing — both work correctly with the same circuit.\n",
+    "\n",
+    "## What's next\n",
+    "\n",
+    "With addition and modular addition in hand, the next step is **controlled modular multiplication** — multiplying by a fixed constant modulo $N$, controlled on a qubit, by repeatedly modulo-adding shifted copies of the multiplicand (binary long multiplication, done reversibly). That's the piece that finally lets us build modular *exponentiation*, and from there, the full algorithm."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tutorial/ja/310_shor.ipynb
+++ b/tutorial/ja/310_shor.ipynb
@@ -589,6 +589,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "0055f67d",
+   "metadata": {},
+   "source": [
+    "**理論だけでなく実際に動く実装が見たい方へ:** 関連シリーズでは、ショアのアルゴリズムを算術演算の部品から少しずつ組み上げていきます。[量子加算器](ja/320_shor_scratch_adder.ipynb)と[剰余加算器](ja/321_shor_scratch_modulo_adder.ipynb)から始まります(準備ができ次第、続きを追加していきます)。"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorial/ja/320_shor_scratch_adder.ipynb
+++ b/tutorial/ja/320_shor_scratch_adder.ipynb
@@ -1,0 +1,292 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7a76945b",
+   "metadata": {},
+   "source": [
+    "# ゼロから作るショアのアルゴリズム 第1回: 量子加算器\n",
+    "\n",
+    "このコレクションの[別のチュートリアル](ja/310_shor.ipynb)では、すでにショアのアルゴリズムの*理論*を最初から最後まで解説しています。\n",
+    "ここから始まるのは、その理論を**実際に動く実装**として、算術演算の部品を1つずつ積み上げていく連載です: 量子加算器 → 剰余加算器 → 制御剰余乗算器 → べき剰余 → アルゴリズム全体。各回は準備ができ次第、順次追加していく予定です。\n",
+    "\n",
+    "今回は、最初の最も基本的な部品である「2つの2進数を足し算する量子回路」を扱います。\n",
+    "\n",
+    "参考文献: V. Vedral, A. Barenco, A. Ekert, [\"Quantum Networks for Elementary Arithmetic Operations\"](https://arxiv.org/abs/quant-ph/9511018) (1995)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3f06543",
+   "metadata": {},
+   "source": [
+    "## なぜ加算器が必要か\n",
+    "\n",
+    "ショアのアルゴリズムの構造をおさらいしましょう(完全な導出は[310_shor.ipynb](ja/310_shor.ipynb)を参照してください)。量子部分がやっているのは、ある $x$ の $N$ を法とした*位数* $r$ (つまり $x^r \\equiv 1 \\pmod N$ となる最小の $r$)を見つけることです。$r$ を見つけることは、多数の $j$ について重ね合わせ状態のまま一斉に $x^j \\bmod N$ を計算すること、すなわち**べき剰余(modular exponentiation)**に帰着します。べき剰余は**制御剰余乗算**の繰り返しから構成され、制御剰余乗算はさらに**剰余加算**の繰り返しから構成されます。つまり、この積み上げの一番下にあるのは「量子コンピュータでどうやって2つの数を足すか」という問題です。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2fcaf3a",
+   "metadata": {},
+   "source": [
+    "## 古典ゲートから量子ゲートへ\n",
+    "\n",
+    "以下の3つの量子ゲートがあれば、任意の古典的(可逆)論理を再現できます。\n",
+    "\n",
+    "| 古典演算 | 量子ゲート |\n",
+    "|:---|:---|\n",
+    "| NOT | `X` |\n",
+    "| XOR | `CX` (CNOT) |\n",
+    "| AND | `CCX` (トフォリ) |\n",
+    "\n",
+    "`CX[a, b]` は量子ビット `a` が `1` のとき量子ビット `b` を反転させます — これはまさに `b := b XOR a` です。`CCX[a, b, c]` は `a` と `b` が*両方とも* `1` のときだけ `c` を反転させます — `c` が `0` から始まる場合、これは `c := c OR (a AND b)` になります。通常の2進数の1桁の足し算は、まさにこの2つの演算だけから構成されます: 桁上げ出力ビットは入力(と繰り上がってきた桁上げ)のANDであり、和ビットは入力(と繰り上がってきた桁上げ)のXORです。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c670a607",
+   "metadata": {},
+   "source": [
+    "## CARRYとSUM\n",
+    "\n",
+    "ある1桁について、入ってくる桁上げを $c$、加数を $a$、$b$、出ていく桁上げを $c_{next}$ とすると、\n",
+    "\n",
+    "```\n",
+    "CARRY: c,a,b,c_next -> c,a,b, c_next XOR (a+b+c の桁上げ)\n",
+    "SUM:   c,a,b         -> c,a, (a XOR b XOR c)\n",
+    "```\n",
+    "\n",
+    "最下位ビットから順に `CARRY` を連鎖させれば、すべての桁上げビットが得られます。その後 `SUM` を使って、各桁上げを対応する和ビットに変換します。量子ゲートは可逆でなければならないため、`CARRY` と `SUM` はどちらも `CCX`/`CX` だけで構成された回路であり、自動的に可逆になっています。このあと `CARRY` の逆演算(`CARRY_INV`)が必要になります。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4ed2c2c4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T05:38:58.414255Z",
+     "iopub.status.busy": "2026-07-13T05:38:58.414007Z",
+     "iopub.status.idle": "2026-07-13T05:38:58.652761Z",
+     "shell.execute_reply": "2026-07-13T05:38:58.651915Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/yuichirominato/.pyenv/shims/pip: line 8: /opt/homebrew/opt/pyenv/bin/pyenv: No such file or directory\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install git+https://github.com/blueqat/blueqatSDK"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "4e48dc71",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T05:38:58.654836Z",
+     "iopub.status.busy": "2026-07-13T05:38:58.654656Z",
+     "iopub.status.idle": "2026-07-13T05:38:59.193595Z",
+     "shell.execute_reply": "2026-07-13T05:38:59.193127Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from blueqat import Circuit\n",
+    "\n",
+    "def carry(c, a, b, c_next):\n",
+    "    \"\"\"CCX[a,b,c_next].CX[a,b].CCX[c,b,c_next] -- propagates the carry out of bit position a+b+c into c_next.\"\"\"\n",
+    "    circ = Circuit()\n",
+    "    circ.ccx[a, b, c_next]\n",
+    "    circ.cx[a, b]\n",
+    "    circ.ccx[c, b, c_next]\n",
+    "    return circ\n",
+    "\n",
+    "def carry_inv(c, a, b, c_next):\n",
+    "    \"\"\"The inverse of carry(): same three (self-inverse) gates, applied in reverse order.\"\"\"\n",
+    "    circ = Circuit()\n",
+    "    circ.ccx[c, b, c_next]\n",
+    "    circ.cx[a, b]\n",
+    "    circ.ccx[a, b, c_next]\n",
+    "    return circ\n",
+    "\n",
+    "def sum_gate(c, a, b):\n",
+    "    \"\"\"CX[a,b].CX[c,b] -- turns b into a XOR b XOR c (the sum bit), leaving a and c unchanged.\"\"\"\n",
+    "    circ = Circuit()\n",
+    "    circ.cx[a, b]\n",
+    "    circ.cx[c, b]\n",
+    "    return circ"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "243d2fcb",
+   "metadata": {},
+   "source": [
+    "## 加算器全体の組み立て\n",
+    "\n",
+    "$n$ビットの数 $a$ と $b$ を足すには $3n+1$ 個の量子ビットが必要で、これを3つのレジスタに分けます。\n",
+    "\n",
+    "- `c[0..n-1]`: 桁上げレジスタ。$\\ket{0}$ から始まる\n",
+    "- `a[0..n-1]`: 1つ目の加数\n",
+    "- `b[0..n]`: 2つ目の加数。**入力より1ビット広い** — 和 $a+b$ は1桁増える可能性があり、最終的な答えはここに格納される\n",
+    "\n",
+    "回路は、下位ビットから `carry` を連鎖させて桁上げを一番上(余分なビットである `b[n]`)まで伝搬させ、最上位ビットに `sum_gate` を適用します。その後、下に向かって戻りながら各ビットで `carry_inv` と `sum_gate` を適用し、残りの和ビットをすべて計算すると同時に、桁上げレジスタを再利用または破棄できるようにきれいに**アンコンピュート**(全て $\\ket{0}$ に戻す)します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "bb11567a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T05:38:59.194845Z",
+     "iopub.status.busy": "2026-07-13T05:38:59.194745Z",
+     "iopub.status.idle": "2026-07-13T05:38:59.197386Z",
+     "shell.execute_reply": "2026-07-13T05:38:59.197104Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def build_adder(input_a, input_b, n):\n",
+    "    \"\"\"n-bit ripple-carry adder. Returns (circuit, b_register_qubit_indices).\"\"\"\n",
+    "    num_qubits = 3 * n + 1\n",
+    "    circ = Circuit(num_qubits)\n",
+    "\n",
+    "    c = list(range(n))\n",
+    "    a = list(range(n, 2 * n))\n",
+    "    b = list(range(2 * n, 3 * n + 1))\n",
+    "\n",
+    "    # Encode the two inputs (c stays at |0...0>)\n",
+    "    for i in range(n):\n",
+    "        if (input_a >> i) & 1:\n",
+    "            circ.x[a[i]]\n",
+    "        if (input_b >> i) & 1:\n",
+    "            circ.x[b[i]]\n",
+    "\n",
+    "    # Ripple the carry up\n",
+    "    for i in range(n - 1):\n",
+    "        circ += carry(c[i], a[i], b[i], c[i + 1])\n",
+    "    circ += carry(c[n - 1], a[n - 1], b[n - 1], b[n])\n",
+    "\n",
+    "    # Top sum bit\n",
+    "    circ.cx[a[n - 1], b[n - 1]]\n",
+    "    circ += sum_gate(c[n - 1], a[n - 1], b[n - 1])\n",
+    "\n",
+    "    # Walk back down: uncompute the carries, filling in the remaining sum bits\n",
+    "    for i in range(n - 2, -1, -1):\n",
+    "        circ += carry_inv(c[i], a[i], b[i], c[i + 1])\n",
+    "        circ += sum_gate(c[i], a[i], b[i])\n",
+    "\n",
+    "    return circ, b"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "325b420b",
+   "metadata": {},
+   "source": [
+    "## 答えの読み出し方\n",
+    "\n",
+    "**ビット順序についての注意**: このSDKの `.run(shots=...)` は、量子ビット0を結果文字列の*右端*の文字として返します(標準的な2進数表記の慣習)。したがって、長さ `N` の結果文字列から量子ビット `q` の値を読み出すには `state[N - 1 - q]` を参照します。`b[0]` は和の最下位ビットなので、`b` レジスタを `b[0]`(最下位)から `b[n]`(最上位)まで読み取り、それに応じて整数値を組み立てます。\n",
+    "\n",
+    "この回路は `X`/`CX`/`CCX` だけ — つまり重ね合わせを作らず量子ビットの値を反転させるだけのゲート — から構成されているため、決まった入力に対しては常に決まった出力が得られます。したがって `shots=1` だけで毎回正確な答えが得られます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1400977a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T05:38:59.198397Z",
+     "iopub.status.busy": "2026-07-13T05:38:59.198337Z",
+     "iopub.status.idle": "2026-07-13T05:38:59.200561Z",
+     "shell.execute_reply": "2026-07-13T05:38:59.200265Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def run_adder(val_a, val_b):\n",
+    "    n = max(val_a, val_b, 1).bit_length()\n",
+    "    circuit, b = build_adder(val_a, val_b, n)\n",
+    "    state = circuit.m[:].run(shots=1).most_common(1)[0][0]\n",
+    "    total_qubits = len(state)\n",
+    "    bits = [state[total_qubits - 1 - q] for q in b]  # bits[0] = LSB\n",
+    "    return int(\"\".join(reversed(bits)), 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "6b071f92",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T05:38:59.201320Z",
+     "iopub.status.busy": "2026-07-13T05:38:59.201268Z",
+     "iopub.status.idle": "2026-07-13T05:38:59.244368Z",
+     "shell.execute_reply": "2026-07-13T05:38:59.244094Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 + 6 = 16  (expected 16, OK)\n",
+      "1 + 1 = 2  (expected 2, OK)\n",
+      "3 + 5 = 8  (expected 8, OK)\n",
+      "7 + 7 = 14  (expected 14, OK)\n",
+      "0 + 5 = 5  (expected 5, OK)\n",
+      "15 + 15 = 30  (expected 30, OK)\n"
+     ]
+    }
+   ],
+   "source": [
+    "for x, y in [(10, 6), (1, 1), (3, 5), (7, 7), (0, 5), (15, 15)]:\n",
+    "    result = run_adder(x, y)\n",
+    "    print(f\"{x} + {y} = {result}  (expected {x + y}, {'OK' if result == x + y else 'MISMATCH'})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d40e8d37",
+   "metadata": {},
+   "source": [
+    "6つのケースすべてが通常の整数の足し算と完全に一致しました。純粋な可逆論理回路であることを考えれば、これは期待通りの結果です。\n",
+    "\n",
+    "## 次回予告\n",
+    "\n",
+    "この加算器は、積み上げの最も内側にある部品です。次のチュートリアルでは、この上に**剰余**加算($a+b \\bmod N$)を実装します — べき剰余のすべての中間値は $[0, N)$ の範囲に収まっている必要があるため、これがショアのアルゴリズムで実際に必要とされる演算です。"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tutorial/ja/321_shor_scratch_modulo_adder.ipynb
+++ b/tutorial/ja/321_shor_scratch_modulo_adder.ipynb
@@ -1,0 +1,344 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8626fcfd",
+   "metadata": {},
+   "source": [
+    "# ゼロから作るショアのアルゴリズム 第2回: 剰余加算器\n",
+    "\n",
+    "[第1回](ja/320_shor_scratch_adder.ipynb)では、通常の量子加算器を作りました。今回はその上に**剰余**加算 $a+b \\bmod N$ を実装します — $x^j \\bmod N$ を計算する過程で生じるすべての中間値は $[0, N)$ の範囲に収める必要があるため、これがショアのアルゴリズムの中で実際に必要とされる演算です。\n",
+    "\n",
+    "参考文献: V. Vedral, A. Barenco, A. Ekert, [\"Quantum Networks for Elementary Arithmetic Operations\"](https://arxiv.org/abs/quant-ph/9511018) (1995), Figure 3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98976d69",
+   "metadata": {},
+   "source": [
+    "## 5ステップのアイデア\n",
+    "\n",
+    "$(a+b) \\bmod N$ は古典的には簡単です: 足し算して、結果が $N$ 以上ならその分だけ $N$ を引きます。しかし量子コンピュータでは、通常のように「確認してから分岐する」ことはできません(それには測定が必要になり、大事にしたい重ね合わせが壊れてしまいます)。代わりに、確認は*量子ビットを使って*行い、条件付きの引き算は*制御回路を使って*行う必要があります。\n",
+    "\n",
+    "1. **足し算**: $b \\leftarrow a + b$(第1回の加算器を使用)\n",
+    "2. **$N$ を引く**: $b \\leftarrow b - N$(加算器を逆向きに実行)\n",
+    "3. **符号を検出**: ステップ2で $b$ が負になった場合、加算器の一番上の余分な量子ビットが $1$ になります(これは借り/オーバーフローのフラグのように働きます) — このビットをフラグ用量子ビット $t$ にコピーします\n",
+    "4. **条件付きで $N$ を足し戻す**: $t=1$ の場合(つまり $a+b < N$ であり、$N$ を引きすぎた場合)、$N$ を足し戻します — ただし重ね合わせの中で $t=1$ になっている枝*だけ*に対して、$t$ を追加の制御量子ビットとして使って行います\n",
+    "5. **後片付け**: $t$ を $\\ket 0$ に戻し、符号検出のステップを元に戻します。これにより回路全体が、$b$ 以外には何も影響を残さないクリーンで再利用可能な操作になります\n",
+    "\n",
+    "ステップ1〜2は加算器/減算器をそのまま使います。ステップ4には回路全体の*制御版*が必要で、これがここでの新しい面白い部分です。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f83c072a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T05:41:17.337659Z",
+     "iopub.status.busy": "2026-07-13T05:41:17.337376Z",
+     "iopub.status.idle": "2026-07-13T05:41:17.575601Z",
+     "shell.execute_reply": "2026-07-13T05:41:17.574781Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/yuichirominato/.pyenv/shims/pip: line 8: /opt/homebrew/opt/pyenv/bin/pyenv: No such file or directory\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install git+https://github.com/blueqat/blueqatSDK"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b42cdce2",
+   "metadata": {},
+   "source": [
+    "## 第1回の部品を再利用する\n",
+    "\n",
+    "前回と同じ `carry`/`carry_inv`/`sum_gate` に加え、それらを組み立てた加算器全体 `add_circuit`、そしてその逆演算 `sub_circuit` を用意します。`sub_circuit` は、同じゲート列を単に逆順に実行するだけで得られます(ここで使われているゲートはすべて `CX` か `CCX` であり、どちらも自己逆元なので、順序を逆にするだけで十分です — 個々のゲートを反転させる必要はありません)。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3d2ad912",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T05:41:17.577391Z",
+     "iopub.status.busy": "2026-07-13T05:41:17.577251Z",
+     "iopub.status.idle": "2026-07-13T05:41:18.123238Z",
+     "shell.execute_reply": "2026-07-13T05:41:18.122783Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from blueqat import Circuit\n",
+    "from blueqat.gate import CXGate, ToffoliGate\n",
+    "\n",
+    "def carry(c, a, b, c_next):\n",
+    "    circ = Circuit()\n",
+    "    circ.ccx[a, b, c_next]\n",
+    "    circ.cx[a, b]\n",
+    "    circ.ccx[c, b, c_next]\n",
+    "    return circ\n",
+    "\n",
+    "def carry_inv(c, a, b, c_next):\n",
+    "    circ = Circuit()\n",
+    "    circ.ccx[c, b, c_next]\n",
+    "    circ.cx[a, b]\n",
+    "    circ.ccx[a, b, c_next]\n",
+    "    return circ\n",
+    "\n",
+    "def sum_gate(c, a, b):\n",
+    "    circ = Circuit()\n",
+    "    circ.cx[a, b]\n",
+    "    circ.cx[c, b]\n",
+    "    return circ\n",
+    "\n",
+    "def add_circuit(c, a, b, n):\n",
+    "    \"\"\"b := a + b, using carry register c. b must have n+1 qubits.\"\"\"\n",
+    "    circ = Circuit()\n",
+    "    for i in range(n - 1):\n",
+    "        circ += carry(c[i], a[i], b[i], c[i + 1])\n",
+    "    circ += carry(c[n - 1], a[n - 1], b[n - 1], b[n])\n",
+    "    circ.cx[a[n - 1], b[n - 1]]\n",
+    "    circ += sum_gate(c[n - 1], a[n - 1], b[n - 1])\n",
+    "    for i in range(n - 2, -1, -1):\n",
+    "        circ += carry_inv(c[i], a[i], b[i], c[i + 1])\n",
+    "        circ += sum_gate(c[i], a[i], b[i])\n",
+    "    return circ\n",
+    "\n",
+    "def sub_circuit(c, a, b, n):\n",
+    "    \"\"\"b := b - a: the adder's gate list, reversed.\"\"\"\n",
+    "    add_circ = add_circuit(c, a, b, n)\n",
+    "    reversed_circ = Circuit()\n",
+    "    reversed_circ.ops = list(reversed(add_circ.ops))\n",
+    "    return reversed_circ"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab583895",
+   "metadata": {},
+   "source": [
+    "## レジスタ構成\n",
+    "\n",
+    "剰余加算器全体には $4n+3$ 個の量子ビットが必要です。\n",
+    "\n",
+    "- `c[0..n-1]`: 桁上げレジスタ(足し算・引き算のステップで共用)\n",
+    "- `a[0..n-1]`: 1つ目の加数\n",
+    "- `b[0..n]`: 2つ目の加数・結果を保持するレジスタ(第1回と同じ $n+1$ 幅のレジスタで、ステップ3ではその最上位ビットがオーバーフロー/借りのフラグを兼ねる)\n",
+    "- `N[0..n-1]`: 法(定数として読み込む)\n",
+    "- `t`: 「$N$ を足し戻す必要があったか」を表すフラグ用量子ビット1個\n",
+    "- 補助量子ビット1個(以下で3制御ゲートを作るためだけに必要)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "faa33076",
+   "metadata": {},
+   "source": [
+    "## ステップ4の詳細: 非制御の加算器から制御付き加算器を作る\n",
+    "\n",
+    "すでに「$b \\leftarrow b + N$」を行う `add_circuit(c, N, b, n)` は持っていますが、ステップ4ではこれを*$t=1$のときだけ*適用する必要があります。つまり、この回路に含まれるすべてのゲートを $t$ で制御したバージョンが必要です。`CX` をもう1つの量子ビットで制御すれば `CCX` になり、これは簡単です。しかし `CCX` をもう1つの量子ビットで制御すると**3制御X**になり、このSDKには直接対応するゲートがありません。標準的なテクニックは次の通りです: 補助量子ビットを1つ使い、最初の2つの制御ビットのANDを `CCX` で補助量子ビットに計算し、その補助量子ビットを2つの制御のうちの1つとして通常の `CCX` を適用し、最後に同じ `CCX` をもう一度使って補助量子ビットを $\\ket 0$ に戻します。結果として、2制御ゲートと一時的な量子ビット1個だけを使って、もう1つ余分な量子ビットで制御された `CCX` を実現できます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "822dfa33",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T05:41:18.124381Z",
+     "iopub.status.busy": "2026-07-13T05:41:18.124280Z",
+     "iopub.status.idle": "2026-07-13T05:41:18.127242Z",
+     "shell.execute_reply": "2026-07-13T05:41:18.126973Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def build_modulo_adder(input_a, input_b, input_N, n):\n",
+    "    \"\"\"b := (a + b) mod N. Returns (circuit, b_register_qubit_indices).\"\"\"\n",
+    "    num_qubits = 4 * n + 3\n",
+    "    circ = Circuit(num_qubits)\n",
+    "\n",
+    "    c = list(range(n))\n",
+    "    a = list(range(n, 2 * n))\n",
+    "    b = list(range(2 * n, 3 * n + 1))\n",
+    "    N = list(range(3 * n + 1, 4 * n + 1))\n",
+    "    t = 4 * n + 1\n",
+    "    ancilla = 4 * n + 2\n",
+    "\n",
+    "    # Encode inputs\n",
+    "    for i in range(n):\n",
+    "        if (input_a >> i) & 1:\n",
+    "            circ.x[a[i]]\n",
+    "        if (input_b >> i) & 1:\n",
+    "            circ.x[b[i]]\n",
+    "        if (input_N >> i) & 1:\n",
+    "            circ.x[N[i]]\n",
+    "\n",
+    "    # Steps 1-2: b <- a + b, then b <- b - N\n",
+    "    circ += add_circuit(c, a, b, n)\n",
+    "    circ += sub_circuit(c, N, b, n)\n",
+    "\n",
+    "    # Step 3: copy the borrow/overflow bit into the flag t\n",
+    "    circ.cx[b[n], t]\n",
+    "\n",
+    "    # Step 4: if t == 1, add N back (t-controlled add_circuit, via the ancilla trick above)\n",
+    "    controlled_add = add_circuit(c, N, b, n)\n",
+    "    for g in controlled_add.ops:\n",
+    "        if isinstance(g, CXGate):\n",
+    "            circ.ccx[t, g.targets[0], g.targets[1]]\n",
+    "        elif isinstance(g, ToffoliGate):\n",
+    "            circ.ccx[t, g.targets[0], ancilla]\n",
+    "            circ.ccx[ancilla, g.targets[1], g.targets[2]]\n",
+    "            circ.ccx[t, g.targets[0], ancilla]\n",
+    "\n",
+    "    # Step 5: clean up -- undo the borrow/overflow detection and reset t to |0>\n",
+    "    circ += sub_circuit(c, a, b, n)\n",
+    "    circ.x[b[n]]\n",
+    "    circ.cx[b[n], t]\n",
+    "    circ.x[b[n]]\n",
+    "    circ += add_circuit(c, a, b, n)\n",
+    "\n",
+    "    return circ, b"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2fa822ca",
+   "metadata": {},
+   "source": [
+    "## テストする\n",
+    "\n",
+    "第1回と同じビット順序の規則を使います: 結果文字列の中で量子ビット `q` は `state[N - 1 - q]` です。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "dd54a576",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T05:41:18.128038Z",
+     "iopub.status.busy": "2026-07-13T05:41:18.127981Z",
+     "iopub.status.idle": "2026-07-13T05:41:18.129595Z",
+     "shell.execute_reply": "2026-07-13T05:41:18.129342Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def run_modulo_adder(val_a, val_b, val_N, n):\n",
+    "    circuit, b = build_modulo_adder(val_a, val_b, val_N, n)\n",
+    "    state = circuit.m[:].run(shots=1).most_common(1)[0][0]\n",
+    "    total_qubits = len(state)\n",
+    "    bits = [state[total_qubits - 1 - q] for q in b]  # bits[0] = LSB\n",
+    "    return int(\"\".join(reversed(bits)), 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d40e0786",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T05:41:18.130360Z",
+     "iopub.status.busy": "2026-07-13T05:41:18.130309Z",
+     "iopub.status.idle": "2026-07-13T05:41:32.155570Z",
+     "shell.execute_reply": "2026-07-13T05:41:32.155122Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(7+6) mod 11 = 2  (expected 2, OK)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(14+13) mod 15 = 12  (expected 12, OK)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(3+5) mod 9 = 8  (expected 8, OK)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(0+0) mod 7 = 0  (expected 0, OK)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(5+5) mod 6 = 4  (expected 4, OK)\n"
+     ]
+    }
+   ],
+   "source": [
+    "tests = [\n",
+    "    (7, 6, 11, 4),\n",
+    "    (14, 13, 15, 4),\n",
+    "    (3, 5, 9, 4),\n",
+    "    (0, 0, 7, 3),\n",
+    "    (5, 5, 6, 3),\n",
+    "]\n",
+    "for x, y, N, n in tests:\n",
+    "    result = run_modulo_adder(x, y, N, n)\n",
+    "    expected = (x + y) % N\n",
+    "    print(f\"({x}+{y}) mod {N} = {result}  (expected {expected}, {'OK' if result == expected else 'MISMATCH'})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28174111",
+   "metadata": {},
+   "source": [
+    "5つのケースすべてが一致しました。このうちいくつかは、両方の分岐を試すように選んでいます: `(7+6) mod 11` は実際に「引いてから足し戻す」補正が必要になる場合です(`7+6=13 \\ge 11`)。一方 `(0+0) mod 7` は決して負にならず、ステップ4では何も起こらないはずです — どちらの場合も、同じ回路で正しく動作します。\n",
+    "\n",
+    "## 次回予告\n",
+    "\n",
+    "足し算と剰余加算ができたので、次のステップは**制御剰余乗算**です — ある定数を、量子ビットで制御しながら $N$ を法として掛ける操作を、被乗数をシフトしたコピーを繰り返し剰余加算することで実現します(可逆的に行う筆算式の掛け算です)。これが、最終的に**べき剰余**、そしてアルゴリズム全体を実装するために必要な部品になります。"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Starts a companion series to the existing theory-focused 310_shor.ipynb, building a working implementation up from arithmetic primitives:

- 320: a plain n-bit quantum adder (CARRY/SUM circuits, uncompute)
- 321: modular addition a+b mod N (Vedral-Barenco-Ekert's add/subtract/ flag/conditional-add-back/cleanup construction), including a 2-control gate emulating a 3-controlled-X via one ancilla qubit

Adapted from the user's own Zenn article series (parts 1-3) on implementing Shor's algorithm with blueqatSDK, with English and Japanese versions of both notebooks. Both were executed end-to-end against the current SDK and verified error-free.

The bitstring-ordering change documented in the previous migration (qubit 0 is now the rightmost character of a shots result) affected the articles' own result-decoding logic and had to be fixed here too, or every test case reads back as wrong-but-plausible answers.

310_shor.ipynb (EN/JA) now links forward to this series, and both READMEs gain a new "Shor's Algorithm from Scratch" section (320-321, more parts to follow as later articles are adapted).