### PR TITLE
Add CHANGELOG, trim README

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -1,0 +1,36 @@
+# 更新履歴
+
+English version is available at [CHANGELOG.md](CHANGELOG.md).
+
+## 2026-07-13 — 新しいblueqatSDKへの移行、日本語訳の追加
+
+全34本のチュートリアルが、古いPyPI版の `blueqat` 0.3.xではなく、現行の[blueqatSDK](https://github.com/blueqat/blueqatSDK)(PyTorchネイティブ版)に対応しました。このリポジトリ(または他の場所)の古いコードが動かなくなった場合、原因はほぼ間違いなく以下の破壊的変更です。
+
+### blueqatSDK自体の破壊的変更
+
+- **`blueqat.pauli` と `blueqat.vqe` が廃止されました。** これまでそこに含まれていたもの — `X`, `Y`, `Z`, `I`, `qubo_bit`, `from_qubo`, `Vqe`, `QaoaAnsatz`, `AnsatzBase`, `VqeResult`, `expect` など — は、すべて `blueqat.utils` に移動しています。`from blueqat.pauli import ...` と `from blueqat.vqe import ...` は `from blueqat.utils import ...` に変更してください。
+- **`qaoa()` 関数が廃止されました。** 代わりに `QaoaAnsatz` + `Vqe` の組み合わせを使用してください。
+  ```python
+  # 旧
+  from blueqat.utils import qaoa
+  result = qaoa(hamiltonian, step, init_circuit, mixer)
+
+  # 新
+  from blueqat.utils import Vqe, QaoaAnsatz
+  result = Vqe(QaoaAnsatz(hamiltonian, step, init_circuit, mixer)).run()
+  ```
+- **`Vqe` は `minimizer=`(SciPy)引数を受け取らなくなりました。** 現在は常にPyTorchの自動微分と `torch.optim` オプティマイザで最適化します: `Vqe(ansatz, optimizer_cls=torch.optim.Adam, optimizer_kwargs={"lr": 0.05})`、`.run(max_iter=500, tol=1e-6)`。
+- **`QaoaAnsatz` の `step` パラメータの意味が変わりました。** 以前は固定された(安価な)トロッター分割の細かさを表しており、`step=200` のような大きな値でも問題ありませんでした。現在は勾配降下法で実際に最適化される変分レイヤーの数を表すため、同じ大きな値だと非常に遅くなります。深さが本当に必要な場合を除き、小さい値(5〜10程度)を使用してください。
+- **カスタムバックエンドの形が変わりました。** ゲート種別ごとのテンプレートメソッド(`_one_qubit_gate_noargs`、`_two_qubit_gate_noargs` など)は廃止されました。カスタムの `Backend` サブクラスは、単一のメソッド `run(self, gates, n_qubits, *args, **kwargs)` だけを実装するようになりました。
+- **`run_with_sympy_unitary()` は廃止されました。** 代わりに `blueqat.circuit_funcs.circuit_to_unitary(circuit)` を使うと、回路のユニタリ行列をNumPy配列として取得できます。
+- **ショット測定のビット列の順序が反転しました。** `Circuit.run(shots=...)` が返す `Counter` のキーは、**量子ビット0が右端の文字**になります(標準的な2進数表記の慣習)。以前は左端でした。コードが旧来の順序を前提としていても例外は発生せず、`key[0]`/`key[:n]` によるインデックス参照や `format(i, '0Nb')` 形式の比較などで、静かに間違った(しかし一見もっともらしい)答えが返ってきます。ノートブックの出力結果が、そのノートブック自身の想定と食い違う場合は、まずこれを疑ってください。
+- **`Circuit.run()` は、状態ベクトルやハミルトニアン期待値の結果としてNumPy配列ではなくPyTorchテンソルを返すようになりました。** 通常は透過的です(表示、演算、`scipy.optimize.minimize` への受け渡しもそのまま機能します)が、後続の処理が `ndarray` を明示的に要求する場合は `.numpy()` を呼んでください。
+- **PyPI版の `blueqat` パッケージは、依然として古い0.3.x系列のままです。** `pip install blueqat` では新しいSDKは手に入りません。代わりに `pip install git+https://github.com/blueqat/blueqatSDK` でインストールしてください。
+- **`openfermionblueqat` は新SDKと非互換です。** `blueqat~=0.3.3` に固定されており、新SDKと一緒にインストールすると環境を古いSDKに静かにダウングレードしてしまいます。新SDKと併用してインストールしないでください。化学系チュートリアル(400〜402)では、`blueqat.utils` を直接使った小さな自作の代替実装(ハミルトニアン変換 + UCC Ansatz)を紹介しています。
+
+### このリポジトリでの変更点
+
+- 既存の全32本のチュートリアルを上記に対応させ、現行SDKの実環境でエラーなく最初から最後まで実行できることを確認しました。
+- 全チュートリアルの日本語訳を `tutorial/ja/` 以下に追加し、新しい[README.ja.md](README.ja.md)からリンクしました。
+- `tutorial/3_ftqc/`(唯一のサブフォルダで、内部の番号付けも不統一でした)をフラット化して `tutorial/` 直下に統合し、READMEがもともと想定していた `300`〜`311` の番号体系に統一しました。
+- 「ゼロから作るショアのアルゴリズム」シリーズを新たに開始しました(現時点で `320`〜`321`: 量子加算器、剰余加算器)。既存の理論解説中心の `310_shor.ipynb` の関連編として、算術演算の部品から実際に動く実装を積み上げていきます。元となる記事シリーズの続きに合わせて、今後も追加していく予定です。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+日本語版は [CHANGELOG.ja.md](CHANGELOG.ja.md) を参照してください。
+
+## 2026-07-13 — Migrated to the new blueqatSDK, added Japanese translations
+
+All 34 tutorials now target the current [blueqatSDK](https://github.com/blueqat/blueqatSDK) (PyTorch-native edition), rather than the old PyPI `blueqat` 0.3.x package. If you have old code (from this repo or elsewhere) that stopped working, the breaking changes below are almost certainly why.
+
+### Breaking changes in blueqatSDK itself
+
+- **`blueqat.pauli` and `blueqat.vqe` no longer exist.** Everything they used to contain — `X`, `Y`, `Z`, `I`, `qubo_bit`, `from_qubo`, `Vqe`, `QaoaAnsatz`, `AnsatzBase`, `VqeResult`, `expect`, etc. — now lives in `blueqat.utils`. Change `from blueqat.pauli import ...` and `from blueqat.vqe import ...` to `from blueqat.utils import ...`.
+- **The `qaoa()` convenience function is gone.** Replace it with the `QaoaAnsatz` + `Vqe` pattern:
+  ```python
+  # old
+  from blueqat.utils import qaoa
+  result = qaoa(hamiltonian, step, init_circuit, mixer)
+
+  # new
+  from blueqat.utils import Vqe, QaoaAnsatz
+  result = Vqe(QaoaAnsatz(hamiltonian, step, init_circuit, mixer)).run()
+  ```
+- **`Vqe` no longer takes a `minimizer=` (SciPy) argument.** It always optimizes with PyTorch autograd + a `torch.optim` optimizer now: `Vqe(ansatz, optimizer_cls=torch.optim.Adam, optimizer_kwargs={"lr": 0.05})`, `.run(max_iter=500, tol=1e-6)`.
+- **`QaoaAnsatz`'s `step` parameter means something different.** It used to be a cheap, fixed Trotter-schedule granularity (large values like `step=200` were fine). It's now the number of variational layers actually optimized by gradient descent, so the same large values are extremely slow. Use small values (5-10) unless you need the extra depth.
+- **Custom backends changed shape.** The old per-gate-type template methods (`_one_qubit_gate_noargs`, `_two_qubit_gate_noargs`, etc.) are gone. A custom `Backend` subclass now implements a single method: `run(self, gates, n_qubits, *args, **kwargs)`.
+- **`run_with_sympy_unitary()` no longer exists.** Use `blueqat.circuit_funcs.circuit_to_unitary(circuit)` to get a circuit's unitary matrix as a NumPy array instead.
+- **Shot-sampling bitstring order is reversed.** `Circuit.run(shots=...)` now returns `Counter` keys with **qubit 0 as the rightmost character** (standard binary-string convention), not the leftmost. This doesn't raise an exception if your code assumed the old order — it just silently produces wrong-but-plausible answers, e.g. from `key[0]`/`key[:n]` indexing or `format(i, '0Nb')`-style comparisons. If a notebook's printed answer doesn't match its own stated expectation, suspect this first.
+- **`Circuit.run()` now returns a PyTorch tensor**, not a NumPy array, for statevector/hamiltonian-expectation results. Usually transparent (printing, arithmetic, and even `scipy.optimize.minimize` all accept it), but call `.numpy()` if something downstream specifically requires an `ndarray`.
+- **PyPI's `blueqat` package is still the old 0.3.x line.** `pip install blueqat` will *not* get you the new SDK — install with `pip install git+https://github.com/blueqat/blueqatSDK` instead.
+- **`openfermionblueqat` is incompatible.** It pins `blueqat~=0.3.3` and will silently downgrade your environment back to the old SDK if installed. Don't install it alongside the new SDK; the chemistry tutorials (400-402) show a small self-contained replacement (Hamiltonian conversion + UCC ansatz) built directly on `blueqat.utils`.
+
+### What changed in this repo
+
+- All 32 existing tutorials updated for the above and verified to execute end-to-end with zero errors against a real install of the current SDK.
+- Added a full Japanese translation of every tutorial, under `tutorial/ja/`, linked from a new [README.ja.md](README.ja.md).
+- Flattened `tutorial/3_ftqc/` (previously the only tutorial subfolder, with inconsistent internal numbering) into the main `tutorial/` directory, renumbered `300`-`311` to match the scheme the README already implied.
+- Started a new "Shor's Algorithm from Scratch" series (`320`-`321` so far: quantum adder, modulo adder) building a working implementation up from arithmetic primitives, as a companion to the existing theory-focused `310_shor.ipynb`. More parts will follow as the source article series continues.

--- a/README.ja.md
+++ b/README.ja.md
@@ -8,6 +8,8 @@ pip install git+https://github.com/blueqat/blueqatSDK
 
 English version is available at [README.md](README.md).
 
+破壊的変更や新着情報は [CHANGELOG.ja.md](CHANGELOG.ja.md) をご覧ください。
+
 0-1. 量子コンピュータの基本操作
 --------------------
 
@@ -67,14 +69,6 @@ English version is available at [README.md](README.md).
 |:---|:---|
 |320.|<a href="tutorial/ja/320_shor_scratch_adder.ipynb">第1回: 量子加算器</a>|
 |321.|<a href="tutorial/ja/321_shor_scratch_modulo_adder.ipynb">第2回: 剰余加算器</a>|
-
-Contributors
-----------
-<a href="https://github.com/Blueqat/Blueqat-tutorials/graphs/contributors" target="_blank">Contributors</a>
-
-Discussions
-----------
-<a href="https://github.com/Blueqat/blueqat-tutorials/discussions" target="_blank">Discussions</a>
 
 Licence
 ----------

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ pip install git+https://github.com/blueqat/blueqatSDK
 
 日本語版のチュートリアルは [README.ja.md](README.ja.md) を参照してください。
 
+See [CHANGELOG.md](CHANGELOG.md) for breaking changes and what's new.
+
 0-1. Basic Operation on Quantum Computer
 --------------------
 
@@ -67,14 +69,6 @@ A companion series to 310 above, building a working implementation of Shor's alg
 |:---|:---|:---|
 |320.|<a href="tutorial/320_shor_scratch_adder.ipynb">Part 1: Quantum Adder</a>|<a href="tutorial/ja/320_shor_scratch_adder.ipynb">日本語</a>|
 |321.|<a href="tutorial/321_shor_scratch_modulo_adder.ipynb">Part 2: Modulo Adder</a>|<a href="tutorial/ja/321_shor_scratch_modulo_adder.ipynb">日本語</a>|
-
-Contributors
-----------
-<a href="https://github.com/Blueqat/Blueqat-tutorials/graphs/contributors" target="_blank">Contributors</a>
-
-Discussions
-----------
-<a href="https://github.com/Blueqat/blueqat-tutorials/discussions" target="_blank">Discussions</a>
 
 Licence
 ----------


### PR DESCRIPTION
## Summary
- Adds `CHANGELOG.md` / `CHANGELOG.ja.md` documenting the blueqatSDK breaking changes and what changed in this repo, for users hitting the same issues in their own code.
- Removes the stale Contributors/Discussions links from both READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)