### PR TITLE
Fix README tutorial number labels to match filenames

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -35,12 +35,12 @@ English version is available at [README.md](README.md).
 |107.|<a href="tutorial/ja/107_matrix_factorization.ipynb">行列分解</a>|
 |108.|<a href="tutorial/ja/108_trafficflow.ipynb">QAOAによる交通流最適化</a>|
 |109.|<a href="tutorial/ja/109_maxcut.ipynb">QAOAによるMaxcut、Exact Cover、グラフ彩色</a>|
-|117.|<a href="tutorial/ja/313_setpacking.ipynb">集合パッキング問題</a>|
-|118.|<a href="tutorial/ja/315_vertexcover.ipynb">頂点被覆問題</a>|
-|119.|<a href="tutorial/ja/316_grover_adaptive_qubo.ipynb">QUBOに対するグローバー適応探索</a>|
-|123.|<a href="tutorial/ja/400_chemistry.ipynb">量子化学とVQE</a>|
-|124.|<a href="tutorial/ja/401_homemadeansatz.ipynb">自作Ansatzを用いたVQE</a>|
-|125.|<a href="tutorial/ja/402_excitedstate.ipynb">励起状態の計算</a>|
+|313.|<a href="tutorial/ja/313_setpacking.ipynb">集合パッキング問題</a>|
+|315.|<a href="tutorial/ja/315_vertexcover.ipynb">頂点被覆問題</a>|
+|316.|<a href="tutorial/ja/316_grover_adaptive_qubo.ipynb">QUBOに対するグローバー適応探索</a>|
+|400.|<a href="tutorial/ja/400_chemistry.ipynb">量子化学とVQE</a>|
+|401.|<a href="tutorial/ja/401_homemadeansatz.ipynb">自作Ansatzを用いたVQE</a>|
+|402.|<a href="tutorial/ja/402_excitedstate.ipynb">励起状態の計算</a>|
 
 3-1. FTQCアルゴリズム
 --------------------

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ See [CHANGELOG.md](CHANGELOG.md) for breaking changes and what's new.
 |107.|<a href="tutorial/107_matrix_factorization.ipynb">Matrix Factorization</a>|<a href="tutorial/ja/107_matrix_factorization.ipynb">日本語</a>|
 |108.|<a href="tutorial/108_trafficflow.ipynb">Traffic Flow Optimization on QAOA</a>|<a href="tutorial/ja/108_trafficflow.ipynb">日本語</a>|
 |109.|<a href="tutorial/109_maxcut.ipynb">Maxcut, Exact Cover, Graph Coloring on QAOA</a>|<a href="tutorial/ja/109_maxcut.ipynb">日本語</a>|
-|117.|<a href="tutorial/313_setpacking.ipynb">Set Packing</a>|<a href="tutorial/ja/313_setpacking.ipynb">日本語</a>|
-|118.|<a href="tutorial/315_vertexcover.ipynb">Vertext Cover</a>|<a href="tutorial/ja/315_vertexcover.ipynb">日本語</a>|
-|119.|<a href="tutorial/316_grover_adaptive_qubo.ipynb">Grover Adaptive Search for QUBO</a>|<a href="tutorial/ja/316_grover_adaptive_qubo.ipynb">日本語</a>|
-|123.|<a href="tutorial/400_chemistry.ipynb">Quantum Chemistry and VQE</a>|<a href="tutorial/ja/400_chemistry.ipynb">日本語</a>|
-|124.|<a href="tutorial/401_homemadeansatz.ipynb">VQE with homemade ansatz</a>|<a href="tutorial/ja/401_homemadeansatz.ipynb">日本語</a>|
-|125.|<a href="tutorial/402_excitedstate.ipynb">Excited state calculation</a>|<a href="tutorial/ja/402_excitedstate.ipynb">日本語</a>|
+|313.|<a href="tutorial/313_setpacking.ipynb">Set Packing</a>|<a href="tutorial/ja/313_setpacking.ipynb">日本語</a>|
+|315.|<a href="tutorial/315_vertexcover.ipynb">Vertext Cover</a>|<a href="tutorial/ja/315_vertexcover.ipynb">日本語</a>|
+|316.|<a href="tutorial/316_grover_adaptive_qubo.ipynb">Grover Adaptive Search for QUBO</a>|<a href="tutorial/ja/316_grover_adaptive_qubo.ipynb">日本語</a>|
+|400.|<a href="tutorial/400_chemistry.ipynb">Quantum Chemistry and VQE</a>|<a href="tutorial/ja/400_chemistry.ipynb">日本語</a>|
+|401.|<a href="tutorial/401_homemadeansatz.ipynb">VQE with homemade ansatz</a>|<a href="tutorial/ja/401_homemadeansatz.ipynb">日本語</a>|
+|402.|<a href="tutorial/402_excitedstate.ipynb">Excited state calculation</a>|<a href="tutorial/ja/402_excitedstate.ipynb">日本語</a>|
 
 3-1. FTQC Algorithms
 --------------------


### PR DESCRIPTION
## Summary
- Six rows in README.md/README.ja.md (Set Packing, Vertex Cover, Grover Adaptive Search, and the three chemistry notebooks) still showed leftover sequential "No." labels (117-119, 123-125) from before those tutorials were renumbered to their current filenames (313, 315, 316, 400, 401, 402).
- Every other row already has its "No." label matching its filename prefix (e.g. `300.` → `300_qft.ipynb`); these six are now consistent with that convention.
- Not a bug in the notebooks themselves — the links worked correctly before this change too, just with a confusing number mismatch. Verified 400/401/402 (and their JA counterparts) have no error cells.

## Test plan
- [x] Scripted check confirms every "No." label across both READMEs now matches its linked filename's number prefix
- [x] Confirmed 400/401/402 chemistry notebooks (EN/JA) have zero error cells

🤖 Generated with [Claude Code](https://claude.com/claude-code)