### PR TITLE
Update LICENSE links after default branch rename to main

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -75,4 +75,4 @@ English version is available at [README.md](README.md).
 
 Licence
 ----------
-<a href="https://github.com/Blueqat/blueqat-tutorials/blob/master/LICENSE">Apache Licence 2.0</a>
+<a href="https://github.com/Blueqat/blueqat-tutorials/blob/main/LICENSE">Apache Licence 2.0</a>

--- a/README.md
+++ b/README.md
@@ -75,5 +75,5 @@ A companion series to 310 above, building a working implementation of Shor's alg
 
 Licence
 ----------
-<a href="https://github.com/Blueqat/blueqat-tutorials/blob/master/LICENSE">Apache Licence 2.0</a>
+<a href="https://github.com/Blueqat/blueqat-tutorials/blob/main/LICENSE">Apache Licence 2.0</a>
 


### PR DESCRIPTION
## Summary
- The default branch was just renamed from `master` to `main`.
- Updates the two remaining hardcoded `/blob/master/LICENSE` links in README.md/README.ja.md to `/blob/main/LICENSE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)