### PR TITLE
Fix stale cross-references, pip install, and JA image paths

### DIFF
--- a/tutorial/003_cloud.ipynb
+++ b/tutorial/003_cloud.ipynb
@@ -23,7 +23,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pip install blueqat-cloud"
+    "!pip install blueqat-cloud"
    ]
   },
   {

--- a/tutorial/209_grover_adaptive_qubo.ipynb
+++ b/tutorial/209_grover_adaptive_qubo.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Grover Adaptive Search and QUBOs\n",
     "\n",
-    "In this tutorial, we shall use a general version of [Grover's algorithm](./111_grover_en.ipynb) and [Quantum Amplitude Amplification](./110_amplitude_amplification_en.ipynb) to provide a quantum algorithm for a general QUBO problem. Note that this is a (complicated) alternative to the QAOA algorithms using gate-model quantum computing.\n",
+    "In this tutorial, we shall use a general version of [Grover's algorithm](./304_qaa_qae_grover_gas.ipynb) and [Quantum Amplitude Amplification](./304_qaa_qae_grover_gas.ipynb) to provide a quantum algorithm for a general QUBO problem. Note that this is a (complicated) alternative to the QAOA algorithms using gate-model quantum computing.\n",
     "\n",
     "It is known that adiabatic quantum computing is equivalent to gate-model quantum computing. An important paper of Roland and Cerf [[1]] prove that the speedup of $O(\\sqrt N)$ obtained via Grover search on an entire solution space of size $N$, is exactly the speedup of the QAOA algorithms.\n",
     "\n",
@@ -128,7 +128,7 @@
     "\n",
     "![Circuit for A_1](./img/323_gas_ckt2.png)\n",
     "\n",
-    "We now implement this on blueqat. Recall the [QFT Circuit](./121_qft_en.ipynb) from our tutorials."
+    "We now implement this on blueqat. Recall the [QFT Circuit](./300_qft.ipynb) from our tutorials."
    ]
   },
   {

--- a/tutorial/302_pea2.ipynb
+++ b/tutorial/302_pea2.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "Authors: Takumi Kato (Blueqat inc.), Maho Nakata (Riken), Shinya Morino, Seiya Sugo (Quemix inc.), Yuichiro Minato (Blueqat inc.)\n",
     "\n",
-    "[Last time](113_pea_en.ipynb), we calculated the eigenvalues of matrices of the Z-Gate and the X-Gate. This time, we perform the quantum phase estimation of a random generated 2x2 Hermitian matrix.\n",
+    "[Last time](301_pea.ipynb), we calculated the eigenvalues of matrices of the Z-Gate and the X-Gate. This time, we perform the quantum phase estimation of a random generated 2x2 Hermitian matrix.\n",
     "\n",
     "Calculating eigenvalues of Hermitian matrices is useful for finding physical quantities in quantum mechanics. It has wide range of applications in fields such as quantum chemistry and quantum simulation."
    ]

--- a/tutorial/303_pea3.ipynb
+++ b/tutorial/303_pea3.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "Authors: Takumi Kato (Blueqat inc.), Maho Nakata (Riken), Shinya Morino, Seiya Sugo (Quemix inc.), Yuichiro Minato (Blueqat inc.)\n",
     "\n",
-    "[Last time](114_pea2_en.ipynb), we calculated the eigenvalues of 2x2 Hermitian matrix. This time, we perform the quantum phase estimation of a random generated 4x4 Hermitian matrix.\n",
+    "[Last time](302_pea2.ipynb), we calculated the eigenvalues of 2x2 Hermitian matrix. This time, we perform the quantum phase estimation of a random generated 4x4 Hermitian matrix.\n",
     "\n",
     "Calculating eigenvalues of Hermitian matrices is useful for finding physical quantities in quantum mechanics. It has wide range of applications in fields such as quantum chemistry and quantum simulation."
    ]

--- a/tutorial/ja/003_cloud.ipynb
+++ b/tutorial/ja/003_cloud.ipynb
@@ -23,7 +23,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pip install blueqat-cloud"
+    "!pip install blueqat-cloud"
    ]
   },
   {

--- a/tutorial/ja/209_grover_adaptive_qubo.ipynb
+++ b/tutorial/ja/209_grover_adaptive_qubo.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Grover Adaptive SearchとQUBO\n",
     "\n",
-    "このチュートリアルでは、[Groverのアルゴリズム](./111_grover_en.ipynb)と[量子振幅増幅](./110_amplitude_amplification_en.ipynb)の一般化版を用いて、一般のQUBO問題を解く量子アルゴリズムを紹介します。これは、ゲート方式の量子コンピューティングを用いたQAOAアルゴリズムに対する(やや複雑な)代替手法であることに注意してください。\n",
+    "このチュートリアルでは、[Groverのアルゴリズム](../304_qaa_qae_grover_gas.ipynb)と[量子振幅増幅](../304_qaa_qae_grover_gas.ipynb)の一般化版を用いて、一般のQUBO問題を解く量子アルゴリズムを紹介します。これは、ゲート方式の量子コンピューティングを用いたQAOAアルゴリズムに対する(やや複雑な)代替手法であることに注意してください。\n",
     "\n",
     "断熱量子計算はゲート方式の量子計算と等価であることが知られています。RolandとCerfによる重要な論文[[1]]は、サイズ$N$の解空間全体に対するGrover探索によって得られる$O(\\sqrt N)$の高速化が、QAOAアルゴリズムの高速化とちょうど一致することを証明しています。\n",
     "\n",
@@ -122,13 +122,13 @@
     "+ 一般に、多項式中の項$ax_{i_1}x_{i_2}\\cdots x_{i_k}$に対しては、$i_1,\\ldots, i_k$番目の量子ビットを制御とし、$j$番目の値レジスタの量子ビットに角度$\\frac{2\\pi}{2^m}\\cdot a\\cdot 2^j$の位相ゲートを適用します。\n",
     "+ 最後に、これらの制御位相演算の後、値レジスタに逆QFTを適用して値レジスタ上に$\\lvert f(x)-y\\rangle$を計算します!以下は$A_y$の回路実装です。\n",
     "\n",
-    "![Circuit for A_1](./img/323_gas_ckt1.png)\n",
+    "![Circuit for A_1](../img/323_gas_ckt1.png)\n",
     "\n",
     "この回路は2量子ビットゲートを使ってさらに簡略化できます。2重制御位相演算はCPhaseゲートとCNOTゲートに分解できるため、次の回路が得られます。\n",
     "\n",
-    "![Circuit for A_1](./img/323_gas_ckt2.png)\n",
+    "![Circuit for A_1](../img/323_gas_ckt2.png)\n",
     "\n",
-    "それでは、これをblueqatで実装しましょう。チュートリアルの[QFT回路](./121_qft_en.ipynb)を思い出してください。"
+    "それでは、これをblueqatで実装しましょう。チュートリアルの[QFT回路](../300_qft.ipynb)を思い出してください。"
    ]
   },
   {
@@ -275,7 +275,7 @@
     "### Groverの拡散演算D\n",
     "blueqat-sdk上で$\\lvert 0000\\rangle$を軸とした反転を実装する必要があります。これは、追加の補助量子ビットを使った次の回路で実現できます。\n",
     "\n",
-    "![Diffusion-ancilla](./img/323_gas_ckt3.png)"
+    "![Diffusion-ancilla](../img/323_gas_ckt3.png)"
    ]
   },
   {

--- a/tutorial/ja/302_pea2.ipynb
+++ b/tutorial/ja/302_pea2.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# ランダムなエルミート行列の量子位相推定\n\n著者: Takumi Kato (Blueqat inc.), Maho Nakata (Riken), Shinya Morino, Seiya Sugo (Quemix inc.), Yuichiro Minato (Blueqat inc.)\n\n[前回](113_pea_en.ipynb)は、Z ゲートと X ゲートの行列の固有値を計算しました。今回は、ランダムに生成した 2x2 のエルミート行列に対する量子位相推定を行います。\n\nエルミート行列の固有値を計算することは、量子力学における物理量を求める上で有用であり、量子化学や量子シミュレーションといった分野で幅広く応用されています。"
+   "source": "# ランダムなエルミート行列の量子位相推定\n\n著者: Takumi Kato (Blueqat inc.), Maho Nakata (Riken), Shinya Morino, Seiya Sugo (Quemix inc.), Yuichiro Minato (Blueqat inc.)\n\n[前回](301_pea.ipynb)は、Z ゲートと X ゲートの行列の固有値を計算しました。今回は、ランダムに生成した 2x2 のエルミート行列に対する量子位相推定を行います。\n\nエルミート行列の固有値を計算することは、量子力学における物理量を求める上で有用であり、量子化学や量子シミュレーションといった分野で幅広く応用されています。"
   },
   {
    "cell_type": "markdown",

--- a/tutorial/ja/303_pea3.ipynb
+++ b/tutorial/ja/303_pea3.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# ランダムな 4x4 エルミート行列の量子位相推定\n\n著者: Takumi Kato (Blueqat inc.), Maho Nakata (Riken), Shinya Morino, Seiya Sugo (Quemix inc.), Yuichiro Minato (Blueqat inc.)\n\n[前回](114_pea2_en.ipynb)は、2x2 のエルミート行列の固有値を計算しました。今回は、ランダムに生成した 4x4 のエルミート行列に対する量子位相推定を行います。\n\nエルミート行列の固有値を計算することは、量子力学における物理量を求める上で有用であり、量子化学や量子シミュレーションといった分野で幅広く応用されています。"
+   "source": "# ランダムな 4x4 エルミート行列の量子位相推定\n\n著者: Takumi Kato (Blueqat inc.), Maho Nakata (Riken), Shinya Morino, Seiya Sugo (Quemix inc.), Yuichiro Minato (Blueqat inc.)\n\n[前回](302_pea2.ipynb)は、2x2 のエルミート行列の固有値を計算しました。今回は、ランダムに生成した 4x4 のエルミート行列に対する量子位相推定を行います。\n\nエルミート行列の固有値を計算することは、量子力学における物理量を求める上で有用であり、量子化学や量子シミュレーションといった分野で幅広く応用されています。"
   },
   {
    "cell_type": "markdown",

--- a/tutorial/ja/304_qaa_qae_grover_gas.ipynb
+++ b/tutorial/ja/304_qaa_qae_grover_gas.ipynb
@@ -947,7 +947,7 @@
     "### グローバー拡散 D\n",
     "blueqat-sdkで $\\lvert 0000\\rangle$ を軸とした反射を実装する必要があります。これは、補助量子ビットを1つ追加した以下の回路で実現できます。\n",
     "\n",
-    "![Diffusion-ancilla](img/323_gas_ckt3.png)"
+    "![Diffusion-ancilla](../img/323_gas_ckt3.png)"
    ]
   },
   {


### PR DESCRIPTION
## Summary
Recovered a small set of legitimate fixes that existed as uncommitted local changes (from earlier work this session) and were about to be discarded during an unrelated branch sync — verified each one and committed properly instead.

- `003_cloud.ipynb`: adds the missing `!` before `pip install blueqat-cloud` (was being interpreted as a plain Python statement, not a shell command, and would have raised a `NameError`).
- `302_pea2.ipynb`, `303_pea3.ipynb`, `209_grover_adaptive_qubo.ipynb` (EN/JA): fixes links pointing to filenames from before the `tutorial/3_ftqc` flattening and subsequent renumbering passes (e.g. `113_pea_en.ipynb`, `111_grover_en.ipynb`, `121_qft_en.ipynb`) — updated to the current filenames.
- `209_grover_adaptive_qubo.ipynb`, `304_qaa_qae_grover_gas.ipynb` (JA only): fixes broken image paths. These notebooks live in `tutorial/ja/`, so reaching `tutorial/img/` needs `../img/...`, not `img/...` (confirmed the EN counterparts already use the correct unprefixed path, since they live directly in `tutorial/`).

## Test plan
- [x] All 9 touched notebooks verified as valid JSON
- [x] Confirmed the `img/` directory only exists at `tutorial/img/`, validating the `../` path fix for `tutorial/ja/` notebooks
- [x] Confirmed EN counterparts needed no image-path change (already correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)