### PR TITLE
Fix broken vertex cover image link

### DIFF
--- a/tutorial/208_vertexcover.ipynb
+++ b/tutorial/208_vertexcover.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "https://en.wikipedia.org/wiki/Vertex_cover\n",
     "\n",
-    "![vertex cover](https://github.com/mdrft/Wildqat/blob/master/examples_ja/img/016_1.png?raw=1)"
+    "![vertex cover](img/016/016_1.png)"
    ]
   },
   {

--- a/tutorial/ja/208_vertexcover.ipynb
+++ b/tutorial/ja/208_vertexcover.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "https://en.wikipedia.org/wiki/Vertex_cover\n",
     "\n",
-    "![vertex cover](https://github.com/mdrft/Wildqat/blob/master/examples_ja/img/016_1.png?raw=1)"
+    "![vertex cover](../img/016/016_1.png)"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- `208_vertexcover.ipynb` (EN/JA) hotlinked its illustration image from a different, unrelated GitHub repo (`mdrft/Wildqat`), whose file has since been moved or removed — the link now 404s.
- The same image already exists locally in this repo at `tutorial/img/016/016_1.png`. Points both notebooks to that local copy instead (with the appropriate `../` prefix for the JA version, which lives one directory deeper).

## Test plan
- [x] Confirmed the external URL returns HTTP 404
- [x] Confirmed the local replacement image exists and renders correctly
- [x] Both notebooks verified as valid JSON after the edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)